### PR TITLE
User customization via "edit" and "extend" buttons (aka persistent store) is broken

### DIFF
--- a/extensions/catalog/catalog.js
+++ b/extensions/catalog/catalog.js
@@ -28,15 +28,14 @@ var Catalog = (function() {
         }
     }
 
-    function Store(namespace, user) {
+    function Store(namespace) {
         this.namespace = "_CATALOG-" + namespace;
-        this.user = user;
     };
 
     Help.Register(Store);
     Store._help = {
         name: "Catalog.Store",
-        description: "A data store for a particular user and namespace."
+        description: "A data store for a particular namespace."
     }
 
     Store.prototype._help_all = {
@@ -47,7 +46,7 @@ var Catalog = (function() {
         var that = this;
 
         if (waitForOperation(function() { that.all(callback); })) {
-            JsDbg.GetPersistentData(this.user, function(result) {
+            JsDbg.GetPersistentData(function(result) {
                 if (result.error) {
                     callback(result);
                 } else if (that.namespace in result.data) {
@@ -69,10 +68,6 @@ var Catalog = (function() {
         ]
     };
     Store.prototype.set = function(key, value, callback) {
-        if (this.user) {
-            throw "You cannot set data on a different user.";
-        }
-
         if (!callback) {
             callback = function() { };
         }
@@ -80,7 +75,7 @@ var Catalog = (function() {
         // Read the current object.
         var that = this;
         if (waitForOperation(function() { that.set(key, value, callback); })) {
-            JsDbg.GetPersistentData(/*user*/null, function(result) {
+            JsDbg.GetPersistentData(function(result) {
                 if (result.error) {
                     callback(result);
                     completedOperation();
@@ -113,10 +108,6 @@ var Catalog = (function() {
         ]
     };
     Store.prototype.setMultiple = function(keysAndValues, callback) {
-        if (this.user) {
-            throw "You cannot set data on a different user.";
-        }
-
         if (!callback) {
             callback = function() { };
         }
@@ -124,7 +115,7 @@ var Catalog = (function() {
         // Read the current object.
         var that = this;
         if (waitForOperation(function() { that.setMultiple(keysAndValues, callback); })) {
-            JsDbg.GetPersistentData(/*user*/null, function(result) {
+            JsDbg.GetPersistentData(function(result) {
                 if (result.error) {
                     callback(result);
                     completedOperation();
@@ -159,10 +150,6 @@ var Catalog = (function() {
         ]
     };
     Store.prototype.delete = function(key, callback) {
-        if (this.user) {
-            throw "You cannot delete keys from a different user.";
-        }
-
         if (!callback) {
             callback = function() { };
         }
@@ -170,7 +157,7 @@ var Catalog = (function() {
         // Read the current object.
         var that = this;
         if (waitForOperation(function() { that.delete(key, callback); })) {
-            JsDbg.GetPersistentData(/*user*/null, function(result) {
+            JsDbg.GetPersistentData(function(result) {
                 if (result.error) {
                     callback(result);
                     completedOperation();

--- a/extensions/extensions-dashboard/extensions-dashboard.js
+++ b/extensions/extensions-dashboard/extensions-dashboard.js
@@ -49,7 +49,7 @@ Loader.OnLoad(function() {
     var panelPromise = new Promise(function (onsuccess) {
         Loader.OnPageReady(function() {
             // Get any startup extensions.
-            JsDbg.GetPersistentData(null, function(data) {
+            JsDbg.GetPersistentData(function(data) {
                 if (typeof(data) == typeof({}) && "_CATALOG-extension-manager" in data) {
                     var extensions = data["_CATALOG-extension-manager"];
                     if (extensions.startup && Array.isArray(extensions.startup) && extensions.startup.length > 0) {

--- a/extensions/jsdbg/core/jsdbg.js
+++ b/extensions/jsdbg/core/jsdbg.js
@@ -477,14 +477,13 @@ Loader.OnLoad(function () {
         },
 
         _help_GetPersistentData: {
-            description: "Gets the persistent data associated with the current user or a specified user.",
+            description: "Gets the persistent data associated with the current user.",
             arguments: [
-                {name:"user", type:"string", description:"(optional) The user whose data should be retrieved."},
                 {name:"callback", type:"function(object)", description:"A callback that is called when the operation succeeds or fails."}
             ]
         },
-        GetPersistentData: function(user, callback) {
-            JsDbgTransport.JsonRequest("/jsdbg-server/persistentstorage" + (user ? "?user=" + esc(user) : ""), callback, JsDbgTransport.CacheType.Uncached, "GET");
+        GetPersistentData: function(callback) {
+            JsDbgTransport.JsonRequest("/jsdbg-server/persistentstorage", callback, JsDbgTransport.CacheType.Uncached, "GET");
         },
 
         _help_SetPersistentData: {

--- a/server/JsDbg.Core/PersistentStore.cs
+++ b/server/JsDbg.Core/PersistentStore.cs
@@ -26,16 +26,14 @@ namespace JsDbg.Core {
         public PersistentStore() {
         }
 
-        private string GetPath(string user) {
-            if (user == null) {
-                user = System.Environment.UserDomainName + "." + System.Environment.UserName;
-            }
-            return user;
-        }
-
-        public Task<string> Get(string user) {
+        public Task<string> Get() {
             return this.AttemptFileOperation<string>(() => {
-                return Task.FromResult<string>(File.ReadAllText(Path.GetTempPath() + PersistentStore.PersistentStoreFileName, PersistentStore.Encoding));
+                string filePath = Path.GetTempPath() + PersistentStore.PersistentStoreFileName;
+                if (File.Exists(filePath)) {
+                    return Task.FromResult<string>(File.ReadAllText(filePath, PersistentStore.Encoding));
+                } else {
+                    return Task.FromResult<string>("{}");
+                }
             });
         }
 

--- a/server/JsDbg.Core/WebServer.cs
+++ b/server/JsDbg.Core/WebServer.cs
@@ -1231,8 +1231,7 @@ namespace JsDbg.Core {
 
         private async void ServePersistentStorage(string[] segments, HttpListenerContext context) {
             if (context.Request.HttpMethod == "GET") {
-                string user = context.Request.QueryString["user"];
-                string result = await this.persistentStore.Get(user);
+                string result = await this.persistentStore.Get();
                 if (result != null) {
                     this.ServeUncachedString(String.Format("{{ \"data\": {0} }}", result), context);
                 } else {


### PR DESCRIPTION
The persistent storage feature was inadvertently broken when it was moved from cloud based storage to local machine storage. The bug happens primary during the initial retrieval (get) from the persistent store - which happens on every page load - and is due to missing the necessary jsdbg persistent store file on the user's local machine. The fix is to check for the existance of the file, and if it doesn't exist, return an empty JSON string to represent the data (or lack thereof) in the persistent store.

In addition, this change removes dead code related to tracking the user's name and domain. This feature was removed from JsDbg prior to open-sourcing, but some parameters (that are now always null or empty string) were not removed from related functions.
 
Fixes #1 