### PR TITLE
Make JsDbg.VisualStudio build with a default installation of VS2017

### DIFF
--- a/server/JsDbg.VisualStudio/JsDbg.VisualStudio.csproj
+++ b/server/JsDbg.VisualStudio/JsDbg.VisualStudio.csproj
@@ -88,6 +88,9 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.CommandBars, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop, Version=8.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
@@ -121,15 +124,6 @@
     <Reference Include="System.Xaml" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="Microsoft.VisualStudio.CommandBars">
-      <Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
     <COMReference Include="stdole">
       <Guid>{00020430-0000-0000-C000-000000000046}</Guid>
       <VersionMajor>2</VersionMajor>

--- a/server/JsDbg.VisualStudio/source.extension.vsixmanifest
+++ b/server/JsDbg.VisualStudio/source.extension.vsixmanifest
@@ -20,5 +20,6 @@
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
         <Prerequisite Id="Microsoft.VisualStudio.Component.VC.CoreIde" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio C++ core features" />
+        <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.VisualStudioExtension.Prerequisites" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio extension development prerequisites" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
It needs a prerequisite entry for VS extension development.
Also, it seems that the CommandBars reference was incorrectly (?)
added, this now looks the same as the Microsoft.VisualStudio.Debugger.Interop
entry.