### PR TITLE
Add support for differentiating global symbols that have the same name but different types

### DIFF
--- a/extensions/dbgobject/core/dbgobject.js
+++ b/extensions/dbgobject/core/dbgobject.js
@@ -120,12 +120,13 @@ Loader.OnLoad(function() {
         returns: "A promise to a DbgObject representing the symbol.",
         arguments: [
             {name:"moduleName", type:"string", description:"The name of the module containing the symbol."},
-            {name:"symbol", type:"string", description:"The global symbol to lookup."}
+            {name:"symbol", type:"string", description:"The global symbol to lookup."},
+            {name: "typeName", type:"string", description: "(optional) The type name of the symbol to look up."}
         ]
     }
-    DbgObject.global = function(moduleName, symbol) {
+    DbgObject.global = function(moduleName, symbol, typeName) {
         return new PromisedDbgObject(
-            moduleBasedLookup(moduleName, JsDbgPromise.LookupGlobalSymbol, symbol)
+            moduleBasedLookup(moduleName, JsDbgPromise.LookupGlobalSymbol, symbol, typeName)
             .then(function(result) {
                 return DbgObject.create(DbgObjectType(result.module, result.type), result.pointer);
             })
@@ -428,10 +429,10 @@ Loader.OnLoad(function() {
         return moduleBasedLookup(that.type.moduleOrSyntheticName(), JsDbgPromise.LookupFieldOffset, that.type.name(), field)
         .then(function(result) {
             return DbgObject.create(
-                getFieldType(that.type, field, DbgObjectType(result.module, result.type)), 
+                getFieldType(that.type, field, DbgObjectType(result.module, result.type)),
                 that.isNull() ? 0 : that._pointer.add(result.offset),
-                result.bitcount, 
-                result.bitoffset, 
+                result.bitcount,
+                result.bitoffset,
                 result.size
             );
         });
@@ -454,7 +455,7 @@ Loader.OnLoad(function() {
         return new PromisedDbgObject(
             moduleBasedLookup(outerType.moduleOrSyntheticName(), JsDbgPromise.LookupFieldOffset, outerType.name(), field)
             .then(function(result) {
-                return DbgObject.create(outerType, that.isNull() ? 0 : that._pointer.add(-result.offset)); 
+                return DbgObject.create(outerType, that.isNull() ? 0 : that._pointer.add(-result.offset));
             })
         );
     }
@@ -705,7 +706,7 @@ Loader.OnLoad(function() {
         description: "Indicates if the type of the DbgObject is one that may have fields.",
         returns: "A promise to a bool."
     };
-    
+
     DbgObject.prototype.isTypeWithFields = function() {
         var that = this;
         return Promise.resolve(null)
@@ -907,7 +908,7 @@ Loader.OnLoad(function() {
         return this.as("void*", true).ubigval()
 
         // Lookup the symbol at that value...
-        .then(function(result) { 
+        .then(function(result) {
             return DbgObject.symbol(result);
         })
         .then(function(vtableSymbol) {
@@ -1071,7 +1072,7 @@ Loader.OnLoad(function() {
 
                 var aSize = bitSize(a.size, a.bitcount);
                 var bSize = bitSize(b.size, b.bitcount);
-                
+
                 // They start at the same offset, so there's a union.  Put the biggest first.
                 if (aSize != bSize) {
                     return bSize - aSize;
@@ -1087,10 +1088,10 @@ Loader.OnLoad(function() {
                     offset: field.offset,
                     size: field.size,
                     value: DbgObject.create(
-                        getFieldType(that.type, field.name, DbgObjectType(field.module, field.type)), 
+                        getFieldType(that.type, field.name, DbgObjectType(field.module, field.type)),
                         that._pointer.isNull() ? 0 : that._pointer.add(field.offset),
-                        field.bitcount, 
-                        field.bitoffset, 
+                        field.bitcount,
+                        field.bitoffset,
                         field.size
                     )
                 };

--- a/extensions/jsdbg/core/jsdbg.js
+++ b/extensions/jsdbg/core/jsdbg.js
@@ -413,7 +413,7 @@ Loader.OnLoad(function () {
             JsDbgTransport.JsonRequest("/jsdbg-server/isenum?module=" + esc(module) + "&type=" + esc(type), callback, JsDbgTransport.CacheType.Cached);
         },
 
-        
+
         _help_LookupConstantName: {
             description: "Looks up the name of a given constant (i.e. an enum value).",
             arguments: [
@@ -445,11 +445,16 @@ Loader.OnLoad(function () {
             arguments: [
                 {name:"module", type:"string", description:"The module containing the symbol."},
                 {name:"symbol", type:"string", description:"The symbol to evaluate."},
+                {name:"typeName", type:"string", description: "The type name of the symbol to look up."},
                 {name:"callback", type:"function(object)", description:"A callback that is called when the operation succeeds or fails."}
             ]
         },
-        LookupGlobalSymbol: function(module, symbol, callback) {
-            JsDbgTransport.JsonRequest("/jsdbg-server/global?module=" + esc(module) + "&symbol=" + esc(symbol), callback, JsDbgTransport.CacheType.Cached);
+        LookupGlobalSymbol: function(module, symbol, typeName, callback) {
+            if (typeName) {
+                JsDbgTransport.JsonRequest("/jsdbg-server/global?module=" + esc(module) + "&symbol=" + esc(symbol) + "&typeName=" + esc(typeName), callback, JsDbgTransport.CacheType.Cached);
+            } else {
+                JsDbgTransport.JsonRequest("/jsdbg-server/global?module=" + esc(module) + "&symbol=" + esc(symbol), callback, JsDbgTransport.CacheType.Cached);
+            }
         },
 
         _help_GetCallStack: {

--- a/server/JsDbg.Core/IDebugger.cs
+++ b/server/JsDbg.Core/IDebugger.cs
@@ -106,7 +106,7 @@ namespace JsDbg.Core {
         Task<IEnumerable<SConstantResult>> LookupConstants(string module, string type, ulong constantValue);
         Task<SConstantResult> LookupConstant(string module, string type, string constantName);
         Task<SFieldResult> LookupField(string module, string typename, string fieldName);
-        Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol);
+        Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol, string typeName);
         Task<SModule> GetModuleForName(string module);
         Task<IEnumerable<SStackFrame>> GetCallStack(int frameCount);
         Task<IEnumerable<SNamedSymbol>> GetSymbolsInStackFrame(ulong instructionAddress, ulong stackAddress, ulong frameAddress);

--- a/server/JsDbg.Core/ITypeCacheDebuggerEngine.cs
+++ b/server/JsDbg.Core/ITypeCacheDebuggerEngine.cs
@@ -60,7 +60,7 @@ namespace JsDbg.Core {
 
         Task<Type> GetTypeFromDebugger(string module, string typename);
 
-        Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol);
+        Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol, string typeName);
 
         Task<SSymbolNameAndDisplacement> LookupSymbolName(ulong pointer);
 

--- a/server/JsDbg.Core/WebServer.cs
+++ b/server/JsDbg.Core/WebServer.cs
@@ -763,6 +763,7 @@ namespace JsDbg.Core {
         private async void ServeGlobalSymbol(NameValueCollection query, Action<string> respond, Action fail) {
             string module = query["module"];
             string symbol = query["symbol"];
+            string typeName = query["typeName"];
 
             if (module == null || symbol == null) {
                 fail();
@@ -770,7 +771,7 @@ namespace JsDbg.Core {
             }
             string responseString;
             try {
-                SSymbolResult result = await this.debugger.LookupGlobalSymbol(module, symbol);
+                SSymbolResult result = await this.debugger.LookupGlobalSymbol(module, symbol, typeName);
                 responseString = String.Format("{{ \"pointer\": {0}, \"module\": \"{1}\", \"type\": \"{2}\" }}", result.Pointer, result.Module, result.Type);
             } catch (DebuggerException ex) {
                 responseString = ex.JSONError;

--- a/server/JsDbg.VisualStudio/DebuggerEngine.cs
+++ b/server/JsDbg.VisualStudio/DebuggerEngine.cs
@@ -212,7 +212,7 @@ namespace JsDbg.VisualStudio {
             throw new DebuggerException("Cannot load types from the Visual Studio debugger directly.");
         }
 
-        public Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol) {
+        public Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol, string typeName) {
             throw new DebuggerException("Cannot load symbols from the Visual Studio debugger directly.");
         }
 

--- a/server/JsDbg.WinDbg/DebuggerEngine.cs
+++ b/server/JsDbg.WinDbg/DebuggerEngine.cs
@@ -295,7 +295,7 @@ namespace JsDbg.WinDbg {
             }, String.Format("Unable to lookup type from debugger: {0}!{1}", module, typename));
         }
 
-        public Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol) {
+        public Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol, string typeName) {
             return this.runner.AttemptOperation<SSymbolResult>(() => {
                 SSymbolResult result = new SSymbolResult();
 
@@ -311,7 +311,11 @@ namespace JsDbg.WinDbg {
 
                 // Now that we have type ids and an offset, we can resolve the names.
                 try {
-                    result.Type = this.symbolCache.GetTypeName(moduleBase, typeId);
+                    string resultTypeName = this.symbolCache.GetTypeName(moduleBase, typeId);
+                    if ((typeName != null) && !resultTypeName.Equals(typeName)) {
+                        throw new DebuggerException(String.Format("Unable to lookup global symbol {0}!{1} with type name {2}", module, symbol, typeName));
+                    }
+                    result.Type = resultTypeName;
                     result.Module = this.symbols.GetModuleNameStringByBaseAddress(ModuleName.Module, moduleBase);
                     return result;
                 } catch {

--- a/server/JsDbg.WinDbg/DebuggerEngine.cs
+++ b/server/JsDbg.WinDbg/DebuggerEngine.cs
@@ -313,7 +313,7 @@ namespace JsDbg.WinDbg {
                 try {
                     string resultTypeName = this.symbolCache.GetTypeName(moduleBase, typeId);
                     if ((typeName != null) && !resultTypeName.Equals(typeName)) {
-                        throw new DebuggerException(String.Format("Unable to lookup global symbol {0}!{1} with type name {2}", module, symbol, typeName));
+                        throw new DebuggerException(String.Format("Unable to lookup global symbol {0}!{1} with type name {2} from debugger", module, symbol, typeName));
                     }
                     result.Type = resultTypeName;
                     result.Module = this.symbols.GetModuleNameStringByBaseAddress(ModuleName.Module, moduleBase);


### PR DESCRIPTION
Currently, the global symbol lookup in the JsDbg server finds the first match and returns it to the client. However, there can be multiple global symbols that have the same symbol name (ex. msedge!instance), with each having a different type. In such cases, the global lookup may not find the correct symbol.

To support this case, an optional "typeName" parameter is being added to the DbgObject.global function, which allows extensions to explicitly specify the type of the global symbol they are looking for. This parameter gets passed all the way down to the server, and the server ensures that a global symbol of the corresponding type is returned (if present).

This type name based lookup is only supported when directly querying the symbol files using DIA APIs, and does not work with the server falls back to looking up symbols from the debugger. The VS debugger does not provide a way to lookup symbols directly from the debugger, while WinDbg does not provide a way to lookup a global symbol with a specific type.