### PR TITLE
Fixing AXTree code to refer to new AXTreeManager instance

### DIFF
--- a/extensions/promise/promise.js
+++ b/extensions/promise/promise.js
@@ -623,14 +623,14 @@ Using '.thenAll' makes this a bit smoother:\
     }
 
     Promise._help_any = {
-        description: "Similar to Promise.all, except it resolves when a single promise provided has succeeded.",
+        description: "Creates a single promise that resolves when any one of the promises in the given iterable resolve.",
         returns: "The succeeded promise.",
         arguments: [
-            {name:"promiseArray", type:"array", description: "The array of promises to evaluate."}
+            {name:"promiseIterable", type:"iterable", description: "The iterable collection (e.g. array) of promises to evaluate."}
         ]
     }
-    Promise.any = function(promiseArray) {
-        return Promise.all(promiseArray.map(p => {
+    Promise.any = function(promiseIterable) {
+        return Promise.all(promiseIterable.map(p => {
             // Invert Promise.all's rejection logic by swapping the pass/fail logic.
             return p.then(
               value => Promise.reject(value),

--- a/extensions/promise/promise.js
+++ b/extensions/promise/promise.js
@@ -621,4 +621,26 @@ Using '.thenAll' makes this a bit smoother:\
         
         return promisedType;
     }
+
+    Promise._help_any = {
+        description: "Similar to Promise.all, except it resolves when a single promise provided has succeeded.",
+        returns: "The succeeded promise.",
+        arguments: [
+            {name:"promiseArray", type:"array", description: "The array of promises to evaluate."}
+        ]
+    }
+    Promise.any = function(promiseArray) {
+        return Promise.all(promiseArray.map(p => {
+            // Invert Promise.all's rejection logic by swapping the pass/fail logic.
+            return p.then(
+              value => Promise.reject(value),
+              error => Promise.resolve(error)
+            );
+          })).then(
+            // If '.all' resolved, there were no resolved promises in the array
+            errors => Promise.reject(errors),
+            // If '.all' rejected, the error value will be the completed promise
+            value => Promise.resolve(value)
+          );
+    }
 })

--- a/extensions/promise/promise.js
+++ b/extensions/promise/promise.js
@@ -623,16 +623,16 @@ Using '.thenAll' makes this a bit smoother:\
     }
 
     Promise._help_any = {
-        description: "Creates a single promise that resolves when any one of the promises in the given iterable resolve.",
+        description: "Creates a single promise that resolves when any one of the promises in the given iterable resolves and rejects if all promises reject.",
         returns: "The succeeded promise.",
         arguments: [
             {name:"promiseIterable", type:"iterable", description: "The iterable collection (e.g. array) of promises to evaluate."}
         ]
     }
     Promise.any = function(promiseIterable) {
-        return Promise.all(promiseIterable.map(p => {
+        return Promise.all(promiseIterable.map(promise => {
             // Invert Promise.all's rejection logic by swapping the pass/fail logic.
-            return p.then(
+            return Promise.resolve(promise).then(
               value => Promise.reject(value),
               error => Promise.resolve(error)
             );

--- a/extensions/target-specific/chromium/ax-tree/ax-tree.js
+++ b/extensions/target-specific/chromium/ax-tree/ax-tree.js
@@ -21,7 +21,7 @@ Loader.OnLoad(function() {
     function getManagers() {
         if (managersPromise == null) {
             // g_ax_tree_id_map was replaced by a specialized AXTreeManagerMap. Check for both in case an older
-            // crash dump is inspected.
+            // build or crash dump is inspected.
             managersPromise = Promise.any([
                 DbgObject.global(Chromium.BrowserProcessSyntheticModuleName, "instance", "base::NoDestructor<ui::AXTreeManagerMap>")
                     .F("Object")

--- a/extensions/target-specific/chromium/chromium-helpers/chromium-helpers.js
+++ b/extensions/target-specific/chromium/chromium-helpers/chromium-helpers.js
@@ -19,6 +19,13 @@ var Chromium = null;
             (lazyInstance) => lazyInstance.f("private_instance_").as(lazyInstance.type.templateParameters()[0] + "*").deref()
         );
 
+        DbgObject.AddExtendedField(
+            (type) => type.name().match(/^base::NoDestructor<.*>/),
+            "Object",
+            (type) => DbgObjectType(type.templateParameters()[0], type),
+            (noDestructor) => noDestructor.f("storage_").as(noDestructor.type.templateParameters()[0])
+        );
+
         Chromium = {
             _help : {
                 name: "Chromium",


### PR DESCRIPTION
This change updates the AXTree code to use either the new AXTreeManager or the older g_ax_tree_id_map for constructing the AXTree.