### PR TITLE
Inspector for a compositor frame

### DIFF
--- a/extensions/target-specific/chromium/chromium-helpers/chromium-helpers.js
+++ b/extensions/target-specific/chromium/chromium-helpers/chromium-helpers.js
@@ -34,6 +34,7 @@ var Chromium = null;
 
             RendererProcessName: "renderer",
             BrowserProcessName: "browser",
+            GpuProcessName: "gpu",
 
             _help_SetTargetProcess: {
                 description: "Sets the name of Chromium process being debugged.",
@@ -45,6 +46,7 @@ var Chromium = null;
 
             RendererProcessSyntheticModuleName: "renderer-module",
             BrowserProcessSyntheticModuleName: "browser-module",
+            GpuProcessSyntheticModuleName: "gpu-module",
 
             _help_RendererProcessType: {
                 description: "Creates a DbgObjectType in the Chromium renderer process.",
@@ -62,6 +64,14 @@ var Chromium = null;
             },
             BrowserProcessType: (typeName) => DbgObjectType(Chromium.BrowserProcessSyntheticModuleName, typeName),
 
+            _help_GpuProcessType: {
+                description: "Creates a DbgObjectType in the Chromium gpu process.",
+                arguments: [
+                    {name:"typeName", type:"string", description: "The type name."}
+                ]
+            },
+            GpuProcessType: (typeName) => DbgObjectType(Chromium.GpuProcessSyntheticModuleName, typeName),
+
             _help_RendererProcessEquivalentModules: {
                 description: "List of modules used in the Chromium renderer process.",
             },
@@ -73,6 +83,11 @@ var Chromium = null;
                 description: "List of modules used in the Chromium browser process.",
             },
             BrowserProcessEquivalentModules: ["msedge", "accessibility", "chrome"],
+
+            _help_GpuProcessEquivalentModules: {
+                description: "List of modules used in the Chromium gpu process.",
+            },
+            GpuProcessEquivalentModules: ["msedge", "service", "chrome"],
 
             _help_MultiProcessModules: {
                 description: "List of modules used in multiple Chromium processes.",
@@ -88,6 +103,8 @@ var Chromium = null;
                         SyntheticModules.RemoveEquivalentModules(Chromium.BrowserProcessSyntheticModuleName, ...Chromium.MultiProcessModules);
                     } else if (currentTargetProcessName == Chromium.RendererProcessName) {
                         SyntheticModules.RemoveEquivalentModules(Chromium.RendererProcessSyntheticModuleName, ...Chromium.MultiProcessModules);
+                    } else if (currentTargetProcessName == Chromium.GpuProcessName) {
+                        SyntheticModules.RemoveEquivalentModules(Chromium.GpuProcessSyntheticModuleName, ...Chromium.MultiProcessModules);
                     } else {
                         console.assert(false);
                     }
@@ -100,6 +117,8 @@ var Chromium = null;
                         SyntheticModules.AddEquivalentModules(Chromium.BrowserProcessSyntheticModuleName, ...Chromium.MultiProcessModules);
                     } else if (currentTargetProcessName == Chromium.RendererProcessName) {
                         SyntheticModules.AddEquivalentModules(Chromium.RendererProcessSyntheticModuleName, ...Chromium.MultiProcessModules);
+                    } else if (currentTargetProcessName == Chromium.GpuProcessName) {
+                        SyntheticModules.AddEquivalentModules(Chromium.GpuProcessSyntheticModuleName, ...Chromium.MultiProcessModules);
                     } else {
                         console.assert(false);
                     }
@@ -109,6 +128,7 @@ var Chromium = null;
 
         SyntheticModules.RegisterSyntheticName(Chromium.RendererProcessSyntheticModuleName, ...Chromium.RendererProcessEquivalentModules);
         SyntheticModules.RegisterSyntheticName(Chromium.BrowserProcessSyntheticModuleName, ...Chromium.BrowserProcessEquivalentModules);
+        SyntheticModules.RegisterSyntheticName(Chromium.GpuProcessSyntheticModuleName, ...Chromium.GpuProcessEquivalentModules);
 
         Help.Register(Chromium);
     });

--- a/extensions/target-specific/chromium/chromium-helpers/chromium-helpers.js
+++ b/extensions/target-specific/chromium/chromium-helpers/chromium-helpers.js
@@ -87,7 +87,7 @@ var Chromium = null;
             _help_GpuProcessEquivalentModules: {
                 description: "List of modules used in the Chromium gpu process.",
             },
-            GpuProcessEquivalentModules: ["msedge", "service", "chrome"],
+            GpuProcessEquivalentModules: ["msedge_child", "service", "chrome_child", "viz_common"],
 
             _help_MultiProcessModules: {
                 description: "List of modules used in multiple Chromium processes.",

--- a/extensions/target-specific/chromium/compositorframe/compositorframe.js
+++ b/extensions/target-specific/chromium/compositorframe/compositorframe.js
@@ -63,7 +63,7 @@ Loader.OnLoad(function () {
                     size--;
                   }
                 }
-                return Promise.all(quads).then((resolvedQuads) => { return resolvedQuads; });
+                return Promise.all(quads);
               });
             });
           });
@@ -85,7 +85,7 @@ Loader.OnLoad(function () {
   );
 
   DbgObject.AddTypeDescription(
-    DbgObjectType("viz_common", "viz::DrawQuad::Resources"),
+    Chromium.GpuProcessType("viz::DrawQuad::Resources"),
     "Resources",
     true,
     UserEditableFunctions.Create((r) => Promise.all([r.f("count").val()])

--- a/extensions/target-specific/chromium/compositorframe/compositorframe.js
+++ b/extensions/target-specific/chromium/compositorframe/compositorframe.js
@@ -88,11 +88,6 @@ Loader.OnLoad(function () {
     Chromium.GpuProcessType("viz::DrawQuad::Resources"),
     "Resources",
     true,
-    UserEditableFunctions.Create((r) => Promise.all([r.f("count").val()])
-      .thenAll((count) => {
-        return r.f("ids").vals(count).then((rs) => {
-          return rs;
-        });
-      }))
+    UserEditableFunctions.Create((r) =>  r.f("ids").vals(r.f("count").val()))
   );
 });

--- a/extensions/target-specific/chromium/compositorframe/compositorframe.js
+++ b/extensions/target-specific/chromium/compositorframe/compositorframe.js
@@ -31,13 +31,13 @@ Loader.OnLoad(function () {
   });
 
   CompositorFrame.Tree.addChildren(Chromium.GpuProcessType("viz::RenderPass"), (parentLayer) => {
-    return Promise.all([parentLayer.f("quad_list").f("helper_").f("data_").F("Object").pointerValue()]).then(
+    return parentLayer.f("quad_list").f("helper_").f("data_").F("Object").as("ntdll!void**").then(
       (charAllocator) => {
-        var voidObj = DbgObject.create("ntdll!void**", charAllocator);
-        if (!voidObj.isNull()) {
+
+        if (!charAllocator.isNull()) {
           // voidObj is a std::vector<std::unique_ptr<InnerList>>
-          return voidObj.size().then((platformPointerSize) => {
-            return voidObj.vals(2).then((val) => {
+          return charAllocator.size().then((platformPointerSize) => {
+            return charAllocator.vals(2).then((val) => {
               // Memory address from val[0] to val[1] contain pointers
               var count = (val[1] - val[0]) / platformPointerSize;
               var address = val[0];

--- a/extensions/target-specific/chromium/compositorframe/compositorframe.js
+++ b/extensions/target-specific/chromium/compositorframe/compositorframe.js
@@ -1,0 +1,102 @@
+//--------------------------------------------------------------
+//
+//    MIT License
+//
+//    Copyright (c) Microsoft Corporation. All rights reserved.
+//
+//--------------------------------------------------------------
+
+"use strict";
+
+var CompositorFrame = undefined;
+Loader.OnLoad(function () {
+  CompositorFrame = {
+    Tree: new DbgObjectTree.DbgObjectTreeReader(),
+    Renderer: new DbgObjectTree.DbgObjectRenderer(),
+    InterpretAddress: function (address) {
+      var voidObj = DbgObject.create("ntdll!void", address);
+      if (!voidObj.isNull()) {
+        return voidObj.as(Chromium.GpuProcessType("viz::CompositorFrame"));
+      }
+      return DbgObject.NULL;
+    },
+    GetRoots: function () {
+      return DbgObject.locals("service", "viz::CompositorFrameSinkImpl::SubmitCompositorFrameInternal", "frame").then(
+        (frames) => {
+          return frames;
+        }
+      );
+    },
+    DefaultTypes: []
+  };
+
+  CompositorFrame.Tree.addChildren(Chromium.GpuProcessType("viz::CompositorFrame"), (parentLayer) => {
+    return parentLayer.f("render_pass_list").array("Elements").map(unique_ptr => { return unique_ptr.F("Object"); });
+  });
+
+  CompositorFrame.Tree.addChildren(Chromium.GpuProcessType("viz::RenderPass"), (parentLayer) => {
+    return Promise.all([parentLayer.f("quad_list").f("helper_").f("data_").F("Object").pointerValue()]).then(
+      (charAllocator) => {
+        var voidObj = DbgObject.create("ntdll!void**", charAllocator);
+        if (!voidObj.isNull()) {
+          // voidObj is a std::vector<std::unique_ptr<InnerList>>
+          return voidObj.size().then((platformPointerSize) => {
+            return voidObj.vals(2).then((val) => {
+              // Memory address from val[0] to val[1] contain pointers
+              var count = (val[1] - val[0]) / platformPointerSize;
+              var address = val[0];
+              var innerListContentsArrayPromises = [];
+              for (var i = 0; i < count; i++) {
+                var innerList = DbgObject.create("ntdll!void**", address);
+                // Inner list has 4 values of interest data,capacity,size,step.
+                innerListContentsArrayPromises.push(innerList.val().then((addrInsertList) => {
+                  return DbgObject.create("ntdll!void**", addrInsertList).vals(4);
+                }));
+                address += platformPointerSize;
+              }
+              return Promise.all(innerListContentsArrayPromises).then((innerListContentsArray) => {
+                var quads = [];
+                for (var i = 0; i < innerListContentsArray.length; i++) {
+                  var data = innerListContentsArray[i][0];
+                  var capacity = innerListContentsArray[i][1];
+                  var size = innerListContentsArray[i][2];
+                  var step = innerListContentsArray[i][3];
+                  while (size > 0) {
+                    quads.push(DbgObject.create("service!viz::DrawQuad", data).vcast());
+                    data += step;
+                    size--;
+                  }
+                }
+                return Promise.all(quads).then((resolvedQuads) => { return resolvedQuads; });
+              });
+            });
+          });
+        }
+      }
+    );
+  });
+
+  CompositorFrame.Renderer.addNameRenderer(DbgObjectType("viz_common", "viz::SolidColorDrawQuad"), (solidColorDrawQuad) => {
+    return solidColorDrawQuad.f("color").val().then((c) => {
+      var a = ((c & 0xFF000000) >> 24) & 0X00000000000000ff;
+      var r = (c & 0x00FF0000) >> 16;
+      var g = (c & 0x0000FF00) >> 8;
+      var b = (c & 0x000000FF);
+      var color = "rgba(" + r + "," + g + "," + b + "," + a + ")";
+      return "SolidColorDrawQuad <span style=\"display:inline-block; vertical-align: middle; width:16px; height:8px; background-color:" + color + "; border:1px solid black;\"></span>";
+    });
+  }
+  );
+
+  DbgObject.AddTypeDescription(
+    DbgObjectType("viz_common", "viz::DrawQuad::Resources"),
+    "Resources",
+    true,
+    UserEditableFunctions.Create((r) => Promise.all([r.f("count").val()])
+      .thenAll((count) => {
+        return r.f("ids").vals(count).then((rs) => {
+          return rs;
+        });
+      }))
+  );
+});

--- a/extensions/target-specific/chromium/compositorframe/compositorframe.js
+++ b/extensions/target-specific/chromium/compositorframe/compositorframe.js
@@ -82,7 +82,7 @@ Loader.OnLoad(function () {
       var r = (c & 0x00FF0000) >> 16;
       var g = (c & 0x0000FF00) >> 8;
       var b = (c & 0x000000FF);
-      var color = "rgba(" + r + "," + g + "," + b + "," + a + ")";
+      var color = "rgba(" + r + "," + g + "," + b + "," + a / 255 + ")";
       return "SolidColorDrawQuad <span style=\"display:inline-block; vertical-align: middle; width:16px; height:8px; background-color:" + color + "; border:1px solid black;\"></span>";
     });
   }

--- a/extensions/target-specific/chromium/compositorframe/compositorframe.js
+++ b/extensions/target-specific/chromium/compositorframe/compositorframe.js
@@ -21,17 +21,13 @@ Loader.OnLoad(function () {
       return DbgObject.NULL;
     },
     GetRoots: function () {
-      return DbgObject.locals("service", "viz::CompositorFrameSinkImpl::SubmitCompositorFrameInternal", "frame").then(
-        (frames) => {
-          return frames;
-        }
-      );
+      return Promise.all([]);
     },
     DefaultTypes: []
   };
 
   CompositorFrame.Tree.addChildren(Chromium.GpuProcessType("viz::CompositorFrame"), (parentLayer) => {
-    return parentLayer.f("render_pass_list").array("Elements").map(unique_ptr => { return unique_ptr.F("Object"); });
+    return parentLayer.f("render_pass_list").array("Elements").map(unique_ptr => unique_ptr.F("Object"));
   });
 
   CompositorFrame.Tree.addChildren(Chromium.GpuProcessType("viz::RenderPass"), (parentLayer) => {

--- a/extensions/target-specific/chromium/compositorframe/extension.json
+++ b/extensions/target-specific/chromium/compositorframe/extension.json
@@ -1,0 +1,25 @@
+{
+    "name": "CompositorFrame",
+    "author": "Sushanth Rajasankar (sushraja)",
+    "description": "Inspect a compositor frame",
+    "dependencies": [
+        "dbgobject",
+        "user-editable-functions",
+        "tree-inspector",
+        "target-specific/stl-helpers",
+        "target-specific/chromium/chromium-helpers",
+        "target-specific/chromium/gfx-type-helpers"
+    ],
+    "includes": [
+        "compositorframe.js"
+    ],
+    "augments": [
+        "dbgobject"
+    ],
+    "targetModules": [
+        "msedge",
+        "chrome",
+        "content_shell",
+        "browser_tests"
+    ]
+}

--- a/extensions/target-specific/chromium/compositorframe/index.html
+++ b/extensions/target-specific/chromium/compositorframe/index.html
@@ -1,0 +1,29 @@
+<!--
+    MIT License
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Inspect Compositor Frame</title>
+    <script type="text/javascript" src="/jsdbg/loader.js"></script>
+    <script type="text/javascript">
+        Loader.OnPageReady(() => {
+            Chromium.SetTargetProcess(Chromium.GpuProcessName);
+
+            TreeInspector.Initialize(
+                CompositorFrame.GetRoots,
+                CompositorFrame.Tree,
+                CompositorFrame.Renderer,
+                CompositorFrame.InterpretAddress,
+                CompositorFrame.DefaultTypes,
+                document.body
+            );
+        })
+    </script>
+</head>
+<body></body>
+</html>

--- a/extensions/target-specific/chromium/extension.json
+++ b/extensions/target-specific/chromium/extension.json
@@ -8,7 +8,8 @@
         "target-specific/chromium/ax-tree",
         "target-specific/chromium/blink",
         "target-specific/chromium/gfx-type-helpers",
-        "target-specific/chromium/cclayertree"
+        "target-specific/chromium/cclayertree",
+        "target-specific/chromium/compositorframe"
     ],
     "targetModules": [
         "msedge",

--- a/extensions/target-specific/chromium/gfx-type-helpers/gfx-type-helpers.js
+++ b/extensions/target-specific/chromium/gfx-type-helpers/gfx-type-helpers.js
@@ -56,7 +56,7 @@ Loader.OnLoad(function() {
     );
 
     DbgObject.AddTypeDescription(
-        DbgObjectType("viz_common", "gfx::Rect"),
+        Chromium.GpuProcessType("gfx::Rect"),
         "Rect",
         true,
         UserEditableFunctions.Create((rect) => Promise.all([rect.f("origin_").f("x_").val(),
@@ -67,7 +67,7 @@ Loader.OnLoad(function() {
     );
 
     DbgObject.AddTypeDescription(
-        DbgObjectType("viz_common", "gfx::RectF"),
+        Chromium.GpuProcessType("gfx::RectF"),
         "Rect",
         true,
         UserEditableFunctions.Create((rect) => Promise.all([rect.f("origin_").f("x_").val(),
@@ -78,7 +78,7 @@ Loader.OnLoad(function() {
     );
 
     DbgObject.AddTypeDescription(
-        DbgObjectType("viz_common", "gfx::Size"),
+        Chromium.GpuProcessType("gfx::Size"),
         "Size",
         true,
         UserEditableFunctions.Create((size) => Promise.all([size.f("width_").val(), size.f("height_").val()])
@@ -86,7 +86,7 @@ Loader.OnLoad(function() {
     );
 
     DbgObject.AddTypeDescription(
-        DbgObjectType("viz_common", "gfx::Transform"),
+        Chromium.GpuProcessType("gfx::Transform"),
         "Size",
         true,
         UserEditableFunctions.Create((transform) => Promise.all([transform.f("matrix_").f("fmat").vals(16)])

--- a/extensions/target-specific/chromium/gfx-type-helpers/gfx-type-helpers.js
+++ b/extensions/target-specific/chromium/gfx-type-helpers/gfx-type-helpers.js
@@ -54,4 +54,51 @@ Loader.OnLoad(function() {
         UserEditableFunctions.Create((scrollOffset) => Promise.all([scrollOffset.f("x_").val(), scrollOffset.f("y_").val()])
             .thenAll((first, second) => `{${first}, ${second}}`))
     );
+
+    DbgObject.AddTypeDescription(
+        DbgObjectType("viz_common", "gfx::Rect"),
+        "Rect",
+        true,
+        UserEditableFunctions.Create((rect) => Promise.all([rect.f("origin_").f("x_").val(),
+          rect.f("origin_").f("y_").val(),
+          rect.f("size_").f("width_").val(),
+          rect.f("size_").f("height_").val()])
+        .thenAll((first, second, third, fourth) => `{${first}, ${second}, ${first + third}, ${second + fourth}}`))
+    );
+
+    DbgObject.AddTypeDescription(
+        DbgObjectType("viz_common", "gfx::RectF"),
+        "Rect",
+        true,
+        UserEditableFunctions.Create((rect) => Promise.all([rect.f("origin_").f("x_").val(),
+          rect.f("origin_").f("y_").val(),
+          rect.f("size_").f("width_").val(),
+          rect.f("size_").f("height_").val()])
+        .thenAll((first, second, third, fourth) => `{${first}, ${second}, ${first + third}, ${second + fourth}}`))
+    );
+
+    DbgObject.AddTypeDescription(
+        DbgObjectType("viz_common", "gfx::Size"),
+        "Size",
+        true,
+        UserEditableFunctions.Create((size) => Promise.all([size.f("width_").val(), size.f("height_").val()])
+            .thenAll((first, second) => `{${first}, ${second}}`))
+    );
+
+    DbgObject.AddTypeDescription(
+        DbgObjectType("viz_common", "gfx::Transform"),
+        "Size",
+        true,
+        UserEditableFunctions.Create((transform) => Promise.all([transform.f("matrix_").f("fmat").vals(16)])
+            .thenAll((mat) => {
+                if (mat[0] == 1 && mat[5] == 1 && mat[10] == 1 && mat[15] == 1 && 
+                    mat[9] == 0 && mat[1] == 0 && mat[2] == 0  && mat[3] ==  0 && 
+                    mat[4] == 0 && mat[6] == 0 && mat[7] == 0  && mat[8] == 0  &&
+                    mat[11] == 0 && mat[14] == 0)
+                {
+                    return "translate("+mat[12]+","+ mat[13]+")";
+                }
+                return mat;
+            }))
+    );    
 })

--- a/extensions/target-specific/chromium/gfx-type-helpers/gfx-type-helpers.js
+++ b/extensions/target-specific/chromium/gfx-type-helpers/gfx-type-helpers.js
@@ -89,8 +89,8 @@ Loader.OnLoad(function() {
         Chromium.GpuProcessType("gfx::Transform"),
         "Size",
         true,
-        UserEditableFunctions.Create((transform) => Promise.all([transform.f("matrix_").f("fmat").vals(16)])
-            .thenAll((mat) => {
+        UserEditableFunctions.Create((transform) => transform.f("matrix_").f("fmat").vals(16)
+            .then((mat) => {
                 if (mat[0] == 1 && mat[5] == 1 && mat[10] == 1 && mat[15] == 1 && 
                     mat[9] == 0 && mat[1] == 0 && mat[2] == 0  && mat[3] ==  0 && 
                     mat[4] == 0 && mat[6] == 0 && mat[7] == 0  && mat[8] == 0  &&


### PR DESCRIPTION
This change implements a visualizer for compositorframe. Break into CompositorFrameSinkImpl::SubmitCompositorFrameInternal 
and then pass the address of &frame in the extension to see the contents of the frame.

on retail builds break into CompositorFrameSinkStubDispatch::Accept and pass 
&p_frame as the address to the extension.

Also included are some visualizers for gfx::Rect,gfx::Size and gfx::Transform