### PR TITLE
Add a gdb command to run jsdbg, instead of running on import

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -261,4 +261,13 @@ def EnsureJsDbg():
         jsdbg = JsDbg()
     return jsdbg
 
-EnsureJsDbg()
+class JsDbgCmd(gdb.Command):
+  """Runs JsDbg."""
+
+  def __init__(self):
+    super(JsDbgCmd, self).__init__("jsdbg", gdb.COMMAND_USER)
+
+  def invoke(self, arg, from_tty):
+    EnsureJsDbg()
+
+JsDbgCmd()


### PR DESCRIPTION
Restores the code that was accidentally deleted in
160a705f46bcf014e727bbedde9e52012805a41d