### PR TITLE
[gdb] Use binascii.hexlify for Python 2 compat

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -2,6 +2,7 @@ import gdb
 import sys
 import subprocess
 import threading
+import binascii
 
 jsdbg = None
             
@@ -248,7 +249,10 @@ def LookupSymbolName(pointer):
 def ReadMemoryBytes(pointer, size):
     inferior = gdb.selected_inferior()
     # Note: will throw an error if this includes unmapped/ unreadable memory
-    return inferior.read_memory(pointer, size).hex()
+    buf = inferior.read_memory(pointer, size)
+    if (sys.version_info < (3, 0)):
+      return binascii.hexlify(bytearray(buf))
+    return buf.hex()
 
 def WriteMemoryBytes(pointer, hexString):
     inferior = gdb.selected_inferior()


### PR DESCRIPTION
There's no hex() method in Python 2.