### PR TITLE
[gdb] Use gdb.lookup_symbol instead of lookup_global_symbol

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -195,7 +195,10 @@ def LookupField(module, type, field):
         fields = [f for m in match for f in m.type.fields()]
 
 def LookupGlobalSymbol(module, symbol):
-    sym = gdb.lookup_global_symbol(symbol)
+    # We can't use lookup_global_symbol because that does not work for symbols
+    # with local linkage, such as those in an anonymous namespace.
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=24474
+    (sym, _) = gdb.lookup_symbol(symbol)
     return SSymbolResult(sym)
 
 def GetCallStack(numFrames):


### PR DESCRIPTION
The latter does not work for variables with local linkage, such as
those in an anonymous namespace, which are a common usage for this
functionality (blink-helper's GetDocuments() needs it)

I've filed https://sourceware.org/bugzilla/show_bug.cgi?id=24474,
but this change will make this feature work until gdb is fixed.