### PR TITLE
[gdb] Also look up constants without the typename

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -229,13 +229,21 @@ def LookupTypeSize(module, typename):
 
 def LookupConstant(module, typename, constantName):
     if typename:
-        val = gdb.parse_and_eval("%s::%s" %(typename, constantName))
+        try:
+            val = gdb.parse_and_eval("%s::%s" %(typename, constantName))
+        except:
+            # Try without the enum name, if it's not an enum class
+            if ("::" in typename):
+                typename = typename[:typename.rfind("::")]
+            else:
+                typename = ""
+            val = gdb.parse_and_eval("%s::%s" %(typename, constantName))
     else:
         val = gdb.parse_and_eval("%s" % constantName)
     # If it is an enum, we could go via type->fields->enumval
     # seems more consistent to just cast to a sufficiently big integral value
 
-    integral_val = val.reinterpret_cast(gdb.lookup_type("unsigned long long"))
+    integral_val = val.cast(gdb.lookup_type("unsigned long long"))
     return str(integral_val)
 
 def LookupSymbolName(pointer):


### PR DESCRIPTION
So that the lookup works also for enums that are not
an enum class.

And use .cast instead of .reinterpret_cast.

Both of these seems to be required at least for
blink::Node::NodeFlags.