### PR TITLE
[gdb] Remove a line of debug output

### DIFF
--- a/server/JsDbg.Gdb/GdbDebugger.cs
+++ b/server/JsDbg.Gdb/GdbDebugger.cs
@@ -48,7 +48,6 @@ namespace JsDbg.Gdb {
                 string[] properties = fieldString.Split('#');
                 Debug.Assert(properties.Length == 6);
                 SFieldResult field = new SFieldResult();
-                Console.WriteLine("GetAllFields: {0}", fieldString);
                 field.Offset = UInt32.Parse(properties[0]);
                 field.Size = UInt32.Parse(properties[1]);
                 field.BitOffset = Byte.Parse(properties[2]);


### PR DESCRIPTION
This confuses the python script who interprets it as a comment.
I could fix it by writing to Console.Error but this does not seem
valuable enough to keep.