### PR TITLE
[gdb] Set Displacement to 0 if it is 2*pointer size

### DIFF
--- a/server/JsDbg.Gdb/GdbDebugger.cs
+++ b/server/JsDbg.Gdb/GdbDebugger.cs
@@ -8,7 +8,7 @@ namespace JsDbg.Gdb {
     class GdbDebugger : IDebugger {
 
         public GdbDebugger() {
-            // TODO: Initialize from LookupTypeSize("void*")
+            // Assume 64-bit until we get a response from the debugger
             IsPointer64Bit = true;
         }
 
@@ -22,6 +22,8 @@ namespace JsDbg.Gdb {
         }
 
         public async Task Run() {
+            Task<uint> task = LookupTypeSize("", "void*");
+
             while(true) {
                 // Pump messages from python back to any waiting handlers
                 string response = await Console.In.ReadLineAsync();
@@ -29,6 +31,7 @@ namespace JsDbg.Gdb {
                     return;
                 }
                 this.OutputDataReceived?.Invoke(this, response);
+                IsPointer64Bit = task.Result == 8 ? true : false;
             }
         }
 

--- a/server/JsDbg.Gdb/GdbDebugger.cs
+++ b/server/JsDbg.Gdb/GdbDebugger.cs
@@ -22,7 +22,9 @@ namespace JsDbg.Gdb {
         }
 
         public async Task Run() {
-            Task<uint> task = LookupTypeSize("", "void*");
+            LookupTypeSize("", "void*").ContinueWith((task) => {
+                IsPointer64Bit = task.Result == 8 ? true : false;
+            });
 
             while(true) {
                 // Pump messages from python back to any waiting handlers
@@ -31,7 +33,6 @@ namespace JsDbg.Gdb {
                     return;
                 }
                 this.OutputDataReceived?.Invoke(this, response);
-                IsPointer64Bit = task.Result == 8 ? true : false;
             }
         }
 


### PR DESCRIPTION
This accounts for the 2 words reserved for RTTI information. Because
the RTTI information is stored "before" the object itself, the vtable
pointer actually points to vtable + 2 pointers. See the link
in this commit for some more context.

DbgObject.symbol (and therefore DbgObject.vcast) requires displacement
to be 0 if you're logically at the beginning of the symbol.