### PR TITLE
[gdb] Look for JsDbg under ~/JsDbg by default

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -3,6 +3,7 @@ import sys
 import subprocess
 import threading
 import binascii
+import os.path
 
 jsdbg = None
             
@@ -28,9 +29,10 @@ class JsDbg:
         self.showStderr = False
         self.verbose = True
         # TODO: assume that jsdbg is installed in "~/.jsdbg/" or some other known location?
-        execPath = "/mnt/c/jsdbg/server/JsDbg.Gdb/bin/Release/netcoreapp2.1/linux-x64/publish/JsDbg.Gdb"
-        extensionsPath = "/mnt/c/jsdbg/extensions"
-        persistentStorePath = "/mnt/c/jsdbg/persistent"
+        homeDir = os.path.expanduser("~")
+        execPath = homeDir + "/JsDbg/server/JsDbg.Gdb/bin/Release/netcoreapp2.1/linux-x64/publish/JsDbg.Gdb"
+        extensionsPath = homeDir + "/JsDbg/extensions"
+        persistentStorePath = homeDir + "/JsDbg/persistent"
         self.proc = subprocess.Popen([execPath, extensionsPath, persistentStorePath], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         def stderrThreadProc():


### PR DESCRIPTION
This should be more likely to work for more people.

Probably still no long-term solution, though.