### PR TITLE
[blink] Add an extended field for DataRef

### DIFF
--- a/extensions/target-specific/chromium/blink/blink-helpers/blink-helpers.js
+++ b/extensions/target-specific/chromium/blink/blink-helpers/blink-helpers.js
@@ -10,6 +10,13 @@
 
 var BlinkHelpers = null;
 Loader.OnLoad(function() {
+    DbgObject.AddExtendedField(
+        (type) => type.name().match(/^blink::DataRef<.*>$/) != null,
+        "Data",
+        (type) => type.templateParameters()[0],
+        (dataRef) => dataRef.f("data_.ptr_")
+    );
+
     DbgObject.AddTypeDescription(Chromium.RendererProcessType("blink::CharacterData"), "data", false, UserEditableFunctions.Create((characterDataNode) => {
         return characterDataNode.f("data_").desc("Text").then(WhitespaceFormatter.CreateFormattedText);
     }));


### PR DESCRIPTION
To more easily go to the pointed object instead of requiring
two steps. Modeled after the std::unique_ptr extended field.