### PR TITLE
Write all logging to Console.Error

### DIFF
--- a/server/JsDbg.Core/WebServer.cs
+++ b/server/JsDbg.Core/WebServer.cs
@@ -119,7 +119,7 @@ namespace JsDbg.Core {
             this.debugger = debugger;
             this.debugger.DebuggerChange += (sender, e) => { this.NotifyClientsOfDebuggerChange(e.Status); };
             this.debugger.DebuggerMessage += (sender, message) => {
-                Console.Out.WriteLine(message);
+                Console.Error.WriteLine(message);
                 this.SendWebSocketMessage(String.Format("message:{0}", message));
             };
             this.persistentStore = persistentStore;
@@ -153,14 +153,14 @@ namespace JsDbg.Core {
                     if (ex.ErrorCode == 5 && !didTryNetsh) {
                         // Access denied, add the url acl and retry.
                         didTryNetsh = true;
-                        Console.Out.WriteLine("Access denied, trying to add URL ACL for {0}.  This may fire an admin prompt.", this.Url);
+                        Console.Error.WriteLine("Access denied, trying to add URL ACL for {0}.  This may fire an admin prompt.", this.Url);
 
                         try {
                             ProcessStartInfo netsh = new ProcessStartInfo("netsh", String.Format(@"http add urlacl url={0} user={1}\{2}", this.Url, Environment.UserDomainName, Environment.UserName));
                             netsh.Verb = "runas";
                             Process.Start(netsh).WaitForExit();
                         } catch (Exception innerEx) {
-                            Console.Out.WriteLine(innerEx.Message);
+                            Console.Error.WriteLine(innerEx.Message);
                             throw innerEx;
                         }
 
@@ -170,18 +170,18 @@ namespace JsDbg.Core {
                         ++this.port;
                         continue;
                     } else {
-                        Console.Out.WriteLine("HttpListenerException with error code {0}: {1}", ex.ErrorCode, ex.Message);
+                        Console.Error.WriteLine("HttpListenerException with error code {0}: {1}", ex.ErrorCode, ex.Message);
                         throw;
                     }
                 } catch (Exception ex) {
-                    Console.Out.WriteLine("HttpListener.Start() threw an exception: {0}", ex.Message);
+                    Console.Error.WriteLine("HttpListener.Start() threw an exception: {0}", ex.Message);
                     throw;
                 }
 
                 break;
             }
 
-            Console.Out.WriteLine("Listening on {0}...", this.Url);
+            Console.Error.WriteLine("Listening on {0}...", this.Url);
 
             try {
                 while (true) {
@@ -223,11 +223,11 @@ namespace JsDbg.Core {
                             continue;
                         }
                     } catch (HttpListenerException listenerException) {
-                        Console.Out.WriteLine("HttpListenerException during request handling: {0}", listenerException.Message);
+                        Console.Error.WriteLine("HttpListenerException during request handling: {0}", listenerException.Message);
                     }
                 }
             } catch (Exception ex) {
-                Console.Out.WriteLine("Unhandled exception during request handling: {0}", ex.Message);
+                Console.Error.WriteLine("Unhandled exception during request handling: {0}", ex.Message);
             }
         }
 
@@ -236,7 +236,7 @@ namespace JsDbg.Core {
                 context.Response.StatusCode = 400;
                 context.Response.OutputStream.Close();
             } catch (Exception exception) {
-                Console.Out.WriteLine("Network Exception: {0}", exception.Message);
+                Console.Error.WriteLine("Network Exception: {0}", exception.Message);
             }
         }
 
@@ -253,14 +253,14 @@ namespace JsDbg.Core {
                 context.Response.OutputStream.Write(buffer, 0, buffer.Length);
                 context.Response.OutputStream.Close();
             } catch (Exception exception) {
-                Console.Out.WriteLine("Network Exception: {0}", exception.Message);
+                Console.Error.WriteLine("Network Exception: {0}", exception.Message);
             }
         }
 
         private void NoteRequest(Uri url) {
             ++this.requestCounter;
 #if DEBUG
-            Console.Out.WriteLineAsync(url.PathAndQuery);
+            Console.Error.WriteLineAsync(url.PathAndQuery);
 #endif
         }
 
@@ -983,7 +983,12 @@ namespace JsDbg.Core {
         public bool LoadExtension(string extensionPath) {
             List<string> failedExtensions = new List<string>();
             string name;
-            return this.LoadExtensionAndDependencies(extensionPath, failedExtensions, out name);
+            bool result = this.LoadExtensionAndDependencies(extensionPath, failedExtensions, out name);
+
+            foreach (var failed in failedExtensions) {
+                Console.Error.WriteLine(String.Format("Failed to load extension: {0}", failed));
+            }
+            return result;
         }
 
         private bool LoadExtensionAndDependencies(string extensionPath, List<string> failedExtensions, out string extensionName) {
@@ -1015,14 +1020,14 @@ namespace JsDbg.Core {
             }
 
             if (extensionToReload != null) {
-                Console.WriteLine("Reloading extension {0} due to a filesystem change.", extensionToReload.name, extensionToReload.OriginalPath);
+                Console.Error.WriteLine("Reloading extension {0} due to a filesystem change.", extensionToReload.name, extensionToReload.OriginalPath);
                 this.UnloadExtension(extensionToReload.name);
                 List<string> failedExtensions = new List<string>();
                 string extensionName;
                 if (this.LoadExtensionAndDependencies(extensionToReload.OriginalPath, failedExtensions, out extensionName)) {
-                    Console.WriteLine("Successfully loaded {0}", extensionName);
+                    Console.Error.WriteLine("Successfully loaded {0}", extensionName);
                 } else {
-                    Console.WriteLine("Failed to load extensions: {0}.  Please fix the extension.json file and reload the extension manually.", String.Join(" -> ", failedExtensions));
+                    Console.Error.WriteLine("Failed to load extensions: {0}.  Please fix the extension.json file and reload the extension manually.", String.Join(" -> ", failedExtensions));
                 }
             }
         }
@@ -1225,7 +1230,7 @@ namespace JsDbg.Core {
                 data = reader.ReadToEnd();
                 return data;
             } catch (Exception exception) {
-                Console.Out.WriteLine("Network Exception: {0}", exception.Message);
+                Console.Error.WriteLine("Network Exception: {0}", exception.Message);
                 return null;
             }
         }
@@ -1450,7 +1455,7 @@ namespace JsDbg.Core {
                     await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Normal", System.Threading.CancellationToken.None);
                 } catch (WebSocketException socketException) {
                     if (this.httpListener.IsListening) {
-                        Console.Out.WriteLine("Closing WebSocket due to WebSocketException: {0}", socketException.Message);
+                        Console.Error.WriteLine("Closing WebSocket due to WebSocketException: {0}", socketException.Message);
                     }
                 } finally {
                     this.openSockets.Remove(socket);


### PR DESCRIPTION
This cherry-picks the logging-related parts of commits
7799d0577f713ae4734501fd58c1e8f6c2d2b93b and
160a705f46bcf014e727bbedde9e52012805a41d from the
jsdbg_gdb_support branch.

Writing to Error helps with gdb because Out is used for
communication between the server and gdb.