### PR TITLE
WTFHelpers: Handle both Latin-1 and UTF-16 strings

### DIFF
--- a/extensions/dbgobject/type/dbgobject-type.js
+++ b/extensions/dbgobject/type/dbgobject-type.js
@@ -79,8 +79,8 @@ Loader.OnLoad(function () {
     }
 
     dbgObjectType.prototype.isUnsigned = function() {
-        // Treat "char" as unsigned.
-        return this.name().indexOf("unsigned ") == this.name() == "char";
+        // Treat "char"s as unsigned.
+        return this.name().startsWith("unsigned ") || this.name().includes("char");
     }
 
     dbgObjectType.prototype.fullName = function() {

--- a/extensions/target-specific/chromium/blink/wtf-helpers/wtf-helpers.js
+++ b/extensions/target-specific/chromium/blink/wtf-helpers/wtf-helpers.js
@@ -21,7 +21,13 @@ Loader.OnLoad(function() {
     }));
 
     DbgObject.AddTypeDescription(Chromium.RendererProcessType("WTF::StringImpl"), "Text", true, UserEditableFunctions.Create((wtfStringImpl) => {
-        return !wtfStringImpl.isNull() ? wtfStringImpl.idx(1).as("char", /*disregardSize*/true).string(wtfStringImpl.f("length_")) : "";
+        if (!wtfStringImpl.isNull()) {
+            return wtfStringImpl.f("is_8bit_").val()
+            .then((is8bit) => wtfStringImpl.idx(1).as(is8bit ? "char" : "char16_t", /*disregardSize*/true))
+            .then((firstChar) => firstChar.string(wtfStringImpl.f("length_")));
+        } else {
+            return "";
+        }
     }));
 
     DbgObject.AddArrayField(


### PR DESCRIPTION
There are two separate issues being fixed with this changes.

First, the .isUnsigned API on DbgObjectType is written incorrectly. This change fixes it work with unsigned values and all char types.

Second, the Text type description for WTF::StringImpl used to unconditionally treat the underlying string as being comprised of 8-bit characters. However, the string may contain 8-bit or 16-bit characters based on the is_8bit_ flag. This is also being fixed herewith so that the type description works for both Latin-1 and UTF-16 strings.