### PR TITLE
Handle exceptions from ServeCurrentProcessThreads and GetAttachedProcesses

### DIFF
--- a/server/JsDbg.Core/WebServer.cs
+++ b/server/JsDbg.Core/WebServer.cs
@@ -1301,7 +1301,13 @@ namespace JsDbg.Core {
         }
 
         private async void ServeAttachedProcesses(NameValueCollection query, Action<string> respond, Action fail) {
-            uint[] processes = await this.debugger.GetAttachedProcesses();
+            uint[] processes;
+            try {
+                processes = await this.debugger.GetAttachedProcesses();
+            } catch (DebuggerException ex) {
+                respond(ex.JSONError);
+                return;
+            }
 
             if (processes == null) {
                 respond(this.JSONError("Unable to access the debugger."));
@@ -1346,7 +1352,13 @@ namespace JsDbg.Core {
         }
 
         private async void ServeCurrentProcessThreads(NameValueCollection query, Action<string> respond, Action fail) {
-            uint[] threads = await this.debugger.GetCurrentProcessThreads();
+            uint[] threads;
+            try {
+                threads = await this.debugger.GetCurrentProcessThreads();
+            } catch (DebuggerException ex) {
+                respond(ex.JSONError);
+                return;
+            }
 
             if (threads == null) {
                 respond(this.JSONError("Unable to access the debugger."));


### PR DESCRIPTION
These can fail on GDB.