### PR TITLE
[gdb] Make the main module match when running under rr

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -255,6 +255,11 @@ def GetModuleForName(module):
     # Python has no API to find the base address
     # https://sourceware.org/bugzilla/show_bug.cgi?id=24481
     return SModule(module, 0)
+  # If we are running under rr, it renames (hardlinks) the executable to
+  # mmap_hardlink_N_foo; allow for that.
+  matches = re.match("^.*/mmap_hardlink_[0-9]+_(.*)$", gdb.current_progspace().filename)
+  if matches and matches.groups()[0] == module:
+    return SModule(module, 0)
   return None
 
 


### PR DESCRIPTION
rr renames the executable; make it match as well so that the
right extensions show up.