### PR TITLE
Handle failed loads of .js files more gracefully

### DIFF
--- a/extensions/jsdbg/loader.js
+++ b/extensions/jsdbg/loader.js
@@ -104,6 +104,7 @@ var Loader = undefined;
         script.type = "text/javascript";
         addPendingResource();
         script.addEventListener("load", pendingResourceFinished);
+        script.addEventListener("error", pendingResourceFinished);
         document.querySelector("head").appendChild(script);
     }
 


### PR DESCRIPTION
Currently, if a JS file fails to load we hang forever even if
the current page actually doesn't need it. It seems better to
also add an error handler to consider it finished even if it
fails.

This is prompted by me noticing that angletextures.js is not loading
with a 404 error, which I have not debugged yet.