### PR TITLE
[angletextures] Fix capitalization of angletextures.js

### DIFF
--- a/extensions/target-specific/chromium/win-d3d11-angletextures/extension.json
+++ b/extensions/target-specific/chromium/win-d3d11-angletextures/extension.json
@@ -13,7 +13,7 @@
         "target-specific/stl-helpers"
     ],
     "includes": [
-        "angletextures.js",
+        "AngleTextures.js",
         "AngleTextures.css"
     ],
     "augments": [


### PR DESCRIPTION
Otherwise, the JS file fails to load on Linux, which is bad even if
the extension doesn't work there anyway.