### PR TITLE
[gdb] Various logging output improvements

### DIFF
--- a/server/JsDbg.Core/WebServer.cs
+++ b/server/JsDbg.Core/WebServer.cs
@@ -119,7 +119,8 @@ namespace JsDbg.Core {
             this.debugger = debugger;
             this.debugger.DebuggerChange += (sender, e) => { this.NotifyClientsOfDebuggerChange(e.Status); };
             this.debugger.DebuggerMessage += (sender, message) => {
-                Console.Error.WriteLine(message);
+                if (this.PrintDebuggerMessages)
+                    Console.Error.WriteLine(message);
                 this.SendWebSocketMessage(String.Format("message:{0}", message));
             };
             this.persistentStore = persistentStore;
@@ -1518,6 +1519,11 @@ namespace JsDbg.Core {
             get { return this.httpListener != null && this.httpListener.IsListening; }
         }
 
+        public bool PrintDebuggerMessages {
+            get { return this.printDebuggerMessages; }
+            set { this.printDebuggerMessages = value; }
+        }
+
         #region IDisposable Members
 
         public void Dispose() {
@@ -1536,5 +1542,6 @@ namespace JsDbg.Core {
         private string extensionRoot;
         private int port;
         private ulong requestCounter;
+        private bool printDebuggerMessages = true;
     }
 }

--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -48,6 +48,10 @@ class JsDbg:
                     print("JsDbg [message]: " + val)
                 elif self.showStderr:
                     print("JsDbg: " + val)
+            # If we get here, the server exited
+            print("JsDbg: server exited or crashed. To restart, type 'jsdbg'.")
+            global jsdbg
+            jsdbg = None
 
         def mainThreadProc():
             # Handle the main interaction loop between jsdbg and python

--- a/server/JsDbg.Gdb/Program.cs
+++ b/server/JsDbg.Gdb/Program.cs
@@ -22,6 +22,8 @@ namespace JsDbg.Gdb
             PersistentStore persistentStore = new PersistentStore();
 
             using (WebServer webServer = new WebServer(debugger, persistentStore, extensionsDirectory)) {
+                // Turn off printing of debugger messages, because they fill up the gdb console too quick.
+                webServer.PrintDebuggerMessages = false;
                 webServer.LoadExtension("default");
 
                 try {


### PR DESCRIPTION
- Don't print debugger messages to stderr on Linux, but keep other stderr
  output. Rationale: debugger messages get too verbose because they get
  intermixed with your gdb session, but other stderr output is useful,
  in particular the server URL gets printed to stderr.
- If the server crashes, show a message to the user and reset the jsdbg
  global, so that typing jsdbg again will do the right thing.