### PR TITLE
[gdb] Handle a "None" return from GetSymbolsInStackFrame

### DIFF
--- a/server/JsDbg.Gdb/GdbDebugger.cs
+++ b/server/JsDbg.Gdb/GdbDebugger.cs
@@ -343,7 +343,8 @@ namespace JsDbg.Gdb {
             NotifyDebuggerMessage("Getting symbols in call stack...");
 
             string pythonResult = await this.QueryDebuggerPython(String.Format("GetSymbolsInStackFrame({0},{1},{2})", instructionAddress, stackAddress, frameAddress));
-            
+            if (pythonResult == "None")
+                throw new DebuggerException("Can't find stack frame");
 
             List<SNamedSymbol> result = new List<SNamedSymbol>();
 

--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -295,6 +295,7 @@ def GetSymbolsInStackFrame(instructionAddress, stackAddress, frameAddress):
             block = block.superblock
         
         return [SNamedSymbol(s, frame) for s in syms]
+    return None
 
 def LookupTypeSize(module, typename):
     typename = typename.strip()


### PR DESCRIPTION
Also makes it more explicit that GetSymbolsInStackFrame
can return None when the frame is not found.