### PR TITLE
[gdb] Fix the last remaining compiler warning

### DIFF
--- a/server/JsDbg.Gdb/GdbDebugger.cs
+++ b/server/JsDbg.Gdb/GdbDebugger.cs
@@ -531,7 +531,9 @@ namespace JsDbg.Gdb {
             string response = await this.QueryDebuggerPython("GetCurrentProcessThreads()");
             return ParsePythonArrayToIntegers(response).ToArray();
         }
-        public async Task<ulong> TebAddress() { return 0; }
+
+        public Task<ulong> TebAddress() { return Task.FromResult(0UL); }
+
         public uint TargetProcess {
             get {
                 return this.targetProcess;


### PR DESCRIPTION
GdbDebugger.cs(534,34): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread. [.../JsDbg/server/JsDbg.Gdb/JsDbg.Gdb.csproj]