### PR TITLE
[gdb] Add a script to package JsDbg for GDB

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -31,10 +31,16 @@ class JsDbg:
     def __init__(self):
         self.showStderr = True
         self.verbose = False
-        # TODO: assume that jsdbg is installed in "~/.jsdbg/" or some other known location?
         homeDir = os.path.expanduser("~")
-        execPath = homeDir + "/JsDbg/server/JsDbg.Gdb/bin/Release/netcoreapp2.1/linux-x64/publish/JsDbg.Gdb"
-        extensionsPath = homeDir + "/JsDbg/extensions"
+        # Check if the binary exists in ~/jsdbg (e.g. the user extracted
+        # the package from create_package.sh in ~)
+        if os.path.exists(homeDir + "/jsdbg/JsDbg.Gdb"):
+            execPath = homeDir + "/jsdbg/JsDbg.Gdb"
+            extensionsPath = homeDir + "/jsdbg/extensions"
+        else:
+            # Assume a development environment with the git repository in ~/JsDbg
+            execPath = homeDir + "/JsDbg/server/JsDbg.Gdb/bin/Release/netcoreapp2.1/linux-x64/publish/JsDbg.Gdb"
+            extensionsPath = homeDir + "/JsDbg/extensions"
         self.proc = subprocess.Popen([execPath, extensionsPath], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         def stderrThreadProc():

--- a/server/JsDbg.Gdb/create_package.sh
+++ b/server/JsDbg.Gdb/create_package.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -ex
+~/dotnet/dotnet publish -c Release -r linux-x64
+cd bin/Release/netcoreapp2.1/linux-x64
+tar --transform='s/publish/jsdbg/' -c -j -f ../../../../jsdbg.tar.bz2 publish/


### PR DESCRIPTION
This adds a script to package JsDbg into a .tar.bz2 file ready
for extracting in the home directory. It also makes JsDbg.py search
for the binary and extensions in ~/jsdbg where the file would
be extracted to.

Note, this requires pull request #91 to be useful.