### PR TITLE
Support std::__Cr::unordered_map and std::__Cr::vector

### DIFF
--- a/extensions/target-specific/chromium/ax-tree/ax-tree.js
+++ b/extensions/target-specific/chromium/ax-tree/ax-tree.js
@@ -27,8 +27,7 @@ Loader.OnLoad(function() {
                     "ui::AXTreeManagerMap::GetInstance()")
                     .F("Object")
                     .f("map_")
-                    .f("_List")
-                    .array("Elements")
+                    .array("Pairs")
                     .f("second"),
                 DbgObject.global(Chromium.BrowserProcessSyntheticModuleName, "g_ax_tree_id_map")
                     .F("Object")


### PR DESCRIPTION
And make ax-tree use the extended field instead of directly accessing
the hashtable, so that it also works with a different STL implementation.

Note, this does not quite make ax-tree work on Linux yet, still figuring
out why.