### PR TITLE
NGPhysicalFragmentTree: Show wrong debuggee error message when using …

### DIFF
--- a/extensions/target-specific/chromium/blink/fragment-tree/fragment-tree.js
+++ b/extensions/target-specific/chromium/blink/fragment-tree/fragment-tree.js
@@ -55,6 +55,10 @@ Loader.OnLoad(function() {
                         ErrorMessages.CreateErrorReasonsList(ErrorMessages.WrongDebuggee("the Chromium renderer process"), ErrorMessages.SymbolsUnavailable);
                     return Promise.reject(errorMessage);
                 });
+            }, (error) => {
+                var errorMessage = ErrorMessages.CreateErrorsList(error) +
+                    ErrorMessages.CreateErrorReasonsList(ErrorMessages.WrongDebuggee("the Chromium renderer process"), ErrorMessages.SymbolsUnavailable);
+                return Promise.reject(errorMessage);
             });
         },
         DefaultTypes: [Chromium.RendererProcessType("blink::NGPhysicalFragment")]


### PR DESCRIPTION
…the extension while attached to the browser process.