### PR TITLE
[gdb] Resolve two TODOs

### DIFF
--- a/server/JsDbg.Gdb/GdbDebugger.cs
+++ b/server/JsDbg.Gdb/GdbDebugger.cs
@@ -443,12 +443,11 @@ namespace JsDbg.Gdb {
             if (result.Name.StartsWith("vtable for ")) {
                 result.Name = result.Name.Substring("vtable for ".Length) + "::`vftable'";
                 ulong pointer_size = IsPointer64Bit ? 8UL : 4UL;
-                if (result.Displacement == 2 * pointer_size) {
-                    // First two words of the vtable are reserved for RTTI.
-                    // http://refspecs.linuxbase.org/cxxabi-1.83.html#rtti-layout
-                    // TODO: Should we subtract 2*pointer_size from all vtable references?
-                    result.Displacement = 0;
-                }
+                // First two words of the vtable are reserved for RTTI.
+                // http://refspecs.linuxbase.org/cxxabi-1.83.html#rtti-layout
+                // For compatibility with Visual Studio, we pretend that the vtable
+                // starts with the first function pointer.
+                result.Displacement -= 2 * pointer_size;
             }
 
             return result;

--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -19,7 +19,6 @@ class JsDbg:
             self.verbose = verbose
 
         def __call__(self):
-            # TODO: wait until at a breakpoint?
             # Need to look at GDB events in python, track "stop" and "cont" evens
             if self.verbose:
                 print("JsDbg [received command]: " + self.request)


### PR DESCRIPTION
I've convinced myself that always subtracting 2*pointer size is the right
thing, because GDB always generates that offset.

Also, there is no need to wait for a breakpoint because many commands
work even while the program is running. Even if we decide to add
such queuing, it would be better to implement it server-side because
C# has better support for that kind of asynchronicity.