### PR TITLE
[gdb] Use virtual 'fp' register for the frame pointer

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -153,7 +153,7 @@ class SStackFrame:
     def __init__(self, frame):
         self.instructionAddress = frame.pc()
         self.stackAddress = frame.read_register("sp")
-        self.frameAddress = frame.read_register("rbp") # TODO: or ebp?
+        self.frameAddress = frame.read_register("fp")
 
     def __repr__(self):
         return '{%d#%d#%d}' % (self.instructionAddress, self.stackAddress, self.frameAddress)


### PR DESCRIPTION
As per https://sourceware.org/gdb/current/onlinedocs/gdb/Registers.html, GDB provides a
virtual 'fp' register for the frame pointer. Unlike 'rbp' this should
work on x86, x64 and ARM, though I've only tested this on x64 and x86.