### PR TITLE
[gdb] Fix handling of GetBaseTypes and multiple inheritance

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -228,7 +228,9 @@ def GetAllFields(module, type, includeBaseTypes):
 
     return resultFields
 
-def GetBaseTypes(module, type):
+# extra_bitoffset is used when we call this function recursively in multiple
+# inheritance cases.
+def GetBaseTypes(module, type, extra_bitoffset=0):
     try:
         t = gdb.lookup_type(type)
         fields = t.fields()
@@ -240,8 +242,8 @@ def GetBaseTypes(module, type):
     for field in fields:
         if not field.is_base_class:
             continue
-        resultFields.append(SBaseTypeResult(module, field.type.name, field.bitpos / 8))
-        resultFields.extend(GetBaseTypes(module, field.type.name))
+        resultFields.append(SBaseTypeResult(module, field.type.name, (extra_bitoffset + field.bitpos) / 8))
+        resultFields.extend(GetBaseTypes(module, field.type.name, extra_bitoffset + field.bitpos))
 
     return resultFields
 


### PR DESCRIPTION
We did not correctly track the offset of recursive base
classes that did not start at offset 0. This is visible,
for example, in the ref_count_ field of ComputedStyle.
With this change, we correctly display it (and sort it
at the end)