### PR TITLE
[gdb] Filter out inferiors that are not running

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -422,7 +422,7 @@ def WriteMemoryBytes(pointer, hexString):
     inferior.write_memory(pointer, byteString)
 
 def GetAttachedProcesses():
-    processes = ', '.join(["%d" % (inferior.pid) for inferior in gdb.inferiors()])
+    processes = ', '.join(["%d" % (inferior.pid) for inferior in gdb.inferiors() if inferior.pid])
     return '[%s]' % (processes)
 
 def GetCurrentProcessThreads():


### PR DESCRIPTION
GDB assigns non-running inferiors a PID of 0; filter them out
as they are not useful.