### PR TITLE
Don't try to auto-update on non-deploy builds

### DIFF
--- a/server/JsDbg.VisualStudio/AutoUpdater.cs
+++ b/server/JsDbg.VisualStudio/AutoUpdater.cs
@@ -32,6 +32,9 @@ namespace JsDbg.VisualStudio {
         }
 
         public static RestartReason CheckForUpdates(string identifier, string updateUrl) {
+            // Don't check for updates on non-DEPLOY builds; the URLs don't work and it seems
+            // undesirable anyway.
+#if DEPLOY
             IVsExtensionManager extensionManager = Package.GetGlobalService(typeof(SVsExtensionManager)) as IVsExtensionManager;
             IInstalledExtension installedExtension = extensionManager.GetInstalledExtension(identifier);
             if (installedExtension == null) {
@@ -63,7 +66,7 @@ namespace JsDbg.VisualStudio {
                     throw;
                 }
             }
-
+#endif
             return RestartReason.None;
         }
 

--- a/server/JsDbg.VisualStudio/JsDbg.VisualStudio.csproj
+++ b/server/JsDbg.VisualStudio/JsDbg.VisualStudio.csproj
@@ -65,6 +65,7 @@
     <Optimize>true</Optimize>
     <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <DefineConstants>DEPLOY</DefineConstants>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>


### PR DESCRIPTION
The URLs don't work, and updating a developer's local build doesn't
seem desirable anyway.