### PR TITLE
[fragment-tree] Show NGLinkStorage in grey

### DIFF
--- a/extensions/target-specific/chromium/blink/fragment-tree/fragment-tree.js
+++ b/extensions/target-specific/chromium/blink/fragment-tree/fragment-tree.js
@@ -73,7 +73,7 @@ Loader.OnLoad(function() {
     });
 
     NGPhysicalFragmentTree.Renderer.addNameRenderer(Chromium.RendererProcessType("blink::NGLinkStorage"), (storage) => {
-        return storage.f("offset").desc().then((offset) => `NGLinkStorage (offset ${offset})`);
+        return storage.f("offset").desc().then((offset) => `<span style="color: grey;">NGLinkStorage (offset ${offset})<span>`);
     });
 
     DbgObject.AddAction(Chromium.RendererProcessType("blink::NGPhysicalFragment"), "NGPhysicalFragmentTree", (fragment) => {


### PR DESCRIPTION
They are not usually the most interesting part of the tree; this
makes the tree visually easier to scan.