### PR TITLE
Adapt code to NGLinkStorage -> NGLink rename

### DIFF
--- a/extensions/target-specific/chromium/blink/blink-helpers/blink-helpers.js
+++ b/extensions/target-specific/chromium/blink/blink-helpers/blink-helpers.js
@@ -575,7 +575,17 @@ Loader.OnLoad(function() {
       });
     }));
 
-    DbgObject.AddArrayField(Chromium.RendererProcessType("blink::NGPhysicalFragment"), "children_", Chromium.RendererProcessType("blink::NGLinkStorage"), UserEditableFunctions.Create((fragment) => {
+    DbgObject.AddArrayField(
+        Chromium.RendererProcessType("blink::NGPhysicalFragment"),
+        "children_",
+        (type) => {
+            // Older builds use NGLinkStorage, newer builds use NGLink -- so
+            // just get the actual type of the field, similar to stl-helpers.js
+            var box_type = new DbgObjectType("blink::NGPhysicalBoxFragment", type);
+            var dummyFragment = DbgObject.create(box_type, 0);
+            return dummyFragment.f("buffer_").then((buf) => buf.type);
+        },
+        UserEditableFunctions.Create((fragment) => {
         return fragment.F("[as container fragment]").then((container) => {
             if (!container.isNull())
                 return container.f("buffer_").array(container.f("num_children_"));

--- a/extensions/target-specific/chromium/blink/fragment-tree/fragment-tree.js
+++ b/extensions/target-specific/chromium/blink/fragment-tree/fragment-tree.js
@@ -68,12 +68,14 @@ Loader.OnLoad(function() {
         return fragment.array("children_");
     });
 
-    NGPhysicalFragmentTree.Tree.addChildren(Chromium.RendererProcessType("blink::NGLinkStorage"), (link) => {
+    // NGLinkStorage is the old name for NGLink
+    NGPhysicalFragmentTree.Tree.addChildren((type) => type.name().match(/^blink::NGLink(Storage)?$/), (link) => {
         return fragmentToConcreteType(link.f("fragment"));
     });
 
-    NGPhysicalFragmentTree.Renderer.addNameRenderer(Chromium.RendererProcessType("blink::NGLinkStorage"), (storage) => {
-        return storage.f("offset").desc().then((offset) => `<span style="color: grey;">NGLinkStorage (offset ${offset})<span>`);
+    // NGLinkStorage is the old name for NGLink
+    NGPhysicalFragmentTree.Renderer.addNameRenderer((type) => type.name().match(/^blink::NGLink(Storage)?$/), (link) => {
+        return link.f("offset").desc().then((offset) => `<span style="color: grey;">${link.type.name()} (offset ${offset})</span>`);
     });
 
     DbgObject.AddAction(Chromium.RendererProcessType("blink::NGPhysicalFragment"), "NGPhysicalFragmentTree", (fragment) => {


### PR DESCRIPTION
In https://crrev.com/c/1621829, NGLinkStorage was renamed. Change
blink-helpers and fragment-tree accordingly, accepting either name.