### PR TITLE
[gdb] Make GetSymbolsInStackFrame work in frames without symbols

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -344,7 +344,11 @@ def GetSymbolsInStackFrame(instructionAddress, stackAddress, frameAddress):
         frame = frame.older()
 
     if frame:
-        block = frame.block()
+        try:
+            block = frame.block()
+        except:
+            # We are probably missing symbols for this frame.
+            return []
         syms = []
         while block and not block.is_global and not block.is_static:
             syms = syms + [s for s in block if s.addr_class != gdb.SYMBOL_LOC_TYPEDEF]


### PR DESCRIPTION
If we don't have symbols for a frame, block() throws an exception. Instead,
just return an empty list.