### PR TITLE
[callstack] Fix the callstack-dashboard extension

### DIFF
--- a/extensions/callstack-dashboard/callstack-dashboard.js
+++ b/extensions/callstack-dashboard/callstack-dashboard.js
@@ -21,7 +21,7 @@ Loader.OnLoad(function() {
     function renderDbgObject(object, renderer) {
         return Promise.all([renderer.createRepresentation(object, null, [], true), object.actions()])
         .thenAll(function (container, actions) {
-            actions.forEach(function (action) { 
+            actions.forEach(function (action) {
                 if (typeof action.action == "string") {
                     var link = document.createElement("a");
                     link.className = "action-button";
@@ -99,8 +99,7 @@ Loader.OnLoad(function() {
                 frame.locals.forEach(function (value, key) {
                     var renderer = new DbgObjectTree.DbgObjectRenderer();
                     renderer.addNameRenderer(
-                        value.module,
-                        function() { return true; },
+                        value.type,
                         function (object) {
                             return key;
                         }

--- a/extensions/callstack/callstack.js
+++ b/extensions/callstack/callstack.js
@@ -38,9 +38,9 @@ Loader.OnLoad(function() {
                 .thenAll(function (frameNames, locals) {
                     return frameNames.map(function (frame, i) {
                         return {
-                            module: DbgObject.NormalizeModule(frame.module),
-                            method: frame.name,
-                            offset: frame.displacement,
+                            module: frame ? frame.module : "??",
+                            method: frame ? frame.name : "??",
+                            offset: frame ? frame.displacement : 0,
                             instructionAddress: stackFrames[i].instructionAddress,
                             stackAddress: stackFrames[i].stackAddress,
                             frameAddress: stackFrames[i].frameAddress,


### PR DESCRIPTION
It was using old APIs in a couple of places. This change also
makes it handle the case when we can't find a symbol for a
stack frame.