### PR TITLE
[gdb] Remove class/struct/etc from type name

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -111,7 +111,8 @@ def FormatType(symbol_type):
         # No good way to interop a function pointer back to python; lie and say it's a void*
         return "void *"
     else:
-        return str(t)
+        typename = str(t)
+        return re.sub(r'^(class|struct|enum|union) ', '', typename)
 
 
 # Input is /foo/bar/libfoo.so, or /foo/bar/some_executable


### PR DESCRIPTION
Some versions of GDB seem to serialize types with a class/struct/etc
prefix; remove it here to not confuse JsDbg.