### PR TITLE
[gdb] Fix incorrect search path

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -35,7 +35,8 @@ class JsDbg:
         rootDir = os.path.dirname(os.path.abspath(__file__))
         extensionSearchPath = [
           rootDir + "/extensions", # from "make package"
-          rootDir + "/../../jsdbg/extensions", # inside a checkout or from "make install"
+          rootDir + "/../../extensions", # inside a checkout
+          rootDir + "/../../jsdbg/extensions", # from "make install"
         ]
         execSearchPath = [
           rootDir + "/JsDbg.Gdb", # from "make package"


### PR DESCRIPTION
I made a mistake in b2e2fefcf1f3be92ad996b2702eef8c1e7eac712;
the search path needs to be different for a checkout vs
an installed path.