### PR TITLE
[gdb] Fix mistake in "make install"

### DIFF
--- a/server/JsDbg.Gdb/Makefile
+++ b/server/JsDbg.Gdb/Makefile
@@ -18,7 +18,7 @@ install: all
 	install -m 644 $(filter-out %createdump %.so, $(BINDEPS)) $(DESTDIR)$(PREFIX)/lib/jsdbg
 	install -m 755 -s $(PUBLISH)/JsDbg.Gdb $(DESTDIR)$(PREFIX)/lib/jsdbg
 	install -d $(DESTDIR)$(PREFIX)/share/jsdbg/extensions
-	cp -r -t $(DESTDIR)$(PREFIX)/share/jsdbg/extensions ../../extensions
+	cp -r -t $(DESTDIR)$(PREFIX)/share/jsdbg/extensions ../../extensions/*
 
 package: all
 	@echo 'Creating jsdbg.tar.bz2'


### PR DESCRIPTION
We want the extensions in the extensions/ directory, not
extensions/extensions.