### PR TITLE
[gdb] Allow 'class' to show up after the beginning

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -132,7 +132,7 @@ def FormatType(symbol_type):
         return "void *"
     else:
         typename = str(t)
-        return re.sub(r'^(class|struct|enum|union) ', '', typename)
+        return re.sub(r'(class|struct|enum|union) ', '', typename)
 
 
 # Input is /foo/bar/libfoo.so, or /foo/bar/some_executable


### PR DESCRIPTION
Some versions of GDB will format this as:
JsDbg [received command]: DebuggerQuery(213,'LookupField("msedge_child","scoped_refptr<blink::NGLayoutResult const>", "ptr_")')
JsDbg [sending response]: 213~{0#8#0#0#ptr_#const class blink::NGLayoutResult *}

Allow the regex to match that too.