### PR TITLE
[gdb] Unify module formatting between GetModuleForName and FormatModule

### DIFF
--- a/server/JsDbg.Gdb/JsDbg_test.py
+++ b/server/JsDbg.Gdb/JsDbg_test.py
@@ -20,7 +20,9 @@ class TestJsDbg(unittest.TestCase):
         self.assertEqual(JsDbg.FormatModule('/foo/libFoo.so'), 'Foo')
         self.assertEqual(JsDbg.FormatModule('/foo/libFoo.so.1'), 'Foo')
         self.assertEqual(JsDbg.FormatModule('/foo/libFoo.so.1.2.3'), 'Foo')
+        self.assertEqual(JsDbg.FormatModule('/foo/mmap_pack_12_libFoo.so.1.2.3'), 'Foo')
         self.assertEqual(JsDbg.FormatModule('/foo/chrome'), 'chrome')
+        self.assertEqual(JsDbg.FormatModule('mmap_hardlink_0_chrome'), 'chrome')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This also makes GetModuleForName a lot simpler.

A side-effect of this is that non-main modules will now show up correctly
when running under rr.