### PR TITLE
[gdb] Remove RuntimeIdentifiers from JsDbg.Gdb project file

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.Gdb.csproj
+++ b/server/JsDbg.Gdb/JsDbg.Gdb.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>osx-x64;linux-x64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>True</TargetLatestRuntimePatch>
   </PropertyGroup>
 


### PR DESCRIPTION
They're not necessary and make offline building fail.