### PR TITLE
[gdb] Add an integration test

### DIFF
--- a/server/JsDbg.Gdb/Makefile
+++ b/server/JsDbg.Gdb/Makefile
@@ -6,7 +6,7 @@ PUBLISH_SC=out_sa
 
 BINDEPS=$(filter-out %extensions %JsDbg.py %JsDbg.Gdb, $(wildcard $(PUBLISH)/*))
 
-all:
+all: bin/test_program
 	$(DOTNET) restore $(RESTOREFLAGS)
 	$(DOTNET) publish -c Release --no-restore -o $(PUBLISH)
 
@@ -19,6 +19,9 @@ install: all
 	install -m 644 $(BINDEPS) $(DESTDIR)$(PREFIX)/lib/jsdbg
 	install -d $(DESTDIR)$(PREFIX)/share/jsdbg/extensions
 	cp -r -t $(DESTDIR)$(PREFIX)/share/jsdbg/extensions ../../extensions/*
+
+bin/test_program: testsuite/test_program.cc
+	$(CXX) $^ -o $@ -g
 
 # We don't want users of the tarball to require a dotnet install, so
 # let's build a self-contained binary.

--- a/server/JsDbg.Gdb/testsuite/README
+++ b/server/JsDbg.Gdb/testsuite/README
@@ -1,0 +1,11 @@
+To run these tests, first install dejagnu: https://www.gnu.org/software/dejagnu/
+You can install it using "apt-get install dejagnu" or "yum install dejagnu".
+
+Then run "runtest" in this directory.
+
+If tests fail, look at "jsdbg.log" for details, or run "runtest -v -v -v"
+for more verbose output, or run "runtest --debug" and check dbg.log for
+more details.
+
+See also the Dejagnu manual here:
+https://www.gnu.org/software/dejagnu/manual/index.html

--- a/server/JsDbg.Gdb/testsuite/jsdbg.tests/basic.exp
+++ b/server/JsDbg.Gdb/testsuite/jsdbg.tests/basic.exp
@@ -1,0 +1,108 @@
+spawn ./rungdb.sh
+
+expect $gdb_prompt
+send "break main\n"
+expect $gdb_prompt
+send "run\n"
+expect $gdb_prompt
+
+send "python print(JsDbg.LookupGlobalSymbol('test_program', 'global_var'))\n"
+test "{int#$decimal}" "LookupGlobalSymbol"
+regexp $decimal $match pointer
+expect $gdb_prompt
+
+send "python print(JsDbg.ModuleForAddress($pointer))\n"
+test "test_program" "ModuleForAddress"
+expect $gdb_prompt
+
+send "python print(JsDbg.GetAllFields('test_program', 'Class', True))\n"
+test "\[\{0#4#0#0#Base#Base}, \{4#4#0#0#member_#int}, \{0#4#0#0#base_member_#int}]" "GetAllFields"
+expect $gdb_prompt
+
+send "python print(JsDbg.GetBaseTypes('test_program', 'Class'))\n"
+test "\[\{test_program#Base#0}]" "GetBaseTypes"
+expect $gdb_prompt
+
+send "python print(JsDbg.IsTypeEnum('test_program', 'Class'))\n"
+test "False" "IsTypeEnum 1"
+expect $gdb_prompt
+
+send "python print(JsDbg.IsTypeEnum('test_program', 'Enum'))\n"
+test "True" "IsTypeEnum 2"
+expect $gdb_prompt
+
+send "python print(JsDbg.LookupField('test_program', 'Class', 'member_'))\n"
+test "\\{4#4#0#0#member_#int}" "LookupField"
+expect $gdb_prompt
+
+send "python print(JsDbg.GetModuleForName('test_program'))\n"
+test "{test_program#0}" "GetModuleForName"
+expect $gdb_prompt
+
+send "python print(JsDbg.GetCallStack(1))\n"
+test "{$decimal#$decimal#$decimal}" "GetCallStack"
+regexp "($decimal)#($decimal)#($decimal)" $match full_match pc sp fp
+expect $gdb_prompt
+
+send "python print(JsDbg.GetSymbolsInStackFrame($pc, $sp, $fp))\n"
+test "\[\{test_program#c#$decimal#Class}, \{test_program#e#$decimal#Enum}]" "GetSymbolsInStackFrame"
+expect $gdb_prompt
+
+send "python print(JsDbg.LookupTypeSize('test_program', 'int'))\n"
+test "4" "LookupTypeSize"
+expect $gdb_prompt
+
+send "python print(JsDbg.LookupConstants('test_program', 'Enum', 1))\n"
+test "\[\{EFirst#1}]" "LookupConstants"
+expect $gdb_prompt
+
+send "python print(JsDbg.LookupConstant('test_program', 'Enum', 'EFirst'))\n"
+test "1" "LookupConstant"
+expect $gdb_prompt
+
+send "python print(JsDbg.LookupSymbolName($pointer))\n"
+test "test_program#global_var#0" "LookupSymbolName"
+expect $gdb_prompt
+
+send "python print(JsDbg.ReadMemoryBytes($pointer, 4))\n"
+test "2a000000" "ReadMemoryBytes"
+expect $gdb_prompt
+
+send "python print(JsDbg.GetAttachedProcesses())\n"
+test "\\\[$decimal]" "GetAttachedProcesses"
+regexp $decimal $match process
+expect $gdb_prompt
+
+send "python print(JsDbg.GetCurrentProcessThreads())\n"
+test "\\\[$decimal]" "GetCurrentProcessThreads"
+regexp $decimal $match thread
+expect $gdb_prompt
+
+send "python print(JsDbg.GetTargetProcess())\n"
+test "$process" "GetTargetProcess"
+expect $gdb_prompt
+
+send "python print(JsDbg.GetTargetThread())\n"
+test "$thread" "GetTargetThread"
+expect $gdb_prompt
+
+send "python JsDbg.SetTargetProcess($process)\n"
+expect {
+  "Error" { fail "SetTargetProcess - Error" }
+  $gdb_prompt {}
+}
+
+send "python JsDbg.SetTargetThread($thread)\n"
+expect {
+  "Error" { fail "SetTargetThread - Error" }
+  $gdb_prompt {}
+}
+
+send "python JsDbg.WriteMemoryBytes($pointer, '10000000')\n"
+expect {
+  "Error" { fail "WriteMemoryBytes - Error" }
+  $gdb_prompt {}
+}
+send "python print(JsDbg.ReadMemoryBytes($pointer, 4))\n"
+test "10000000" "ReadMemoryBytes after write"
+expect $gdb_prompt

--- a/server/JsDbg.Gdb/testsuite/rungdb.sh
+++ b/server/JsDbg.Gdb/testsuite/rungdb.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -x
+exec gdb -nx \
+  -ex 'python import sys' \
+  -ex 'python import os' \
+  -ex 'python sys.path.insert(0, os.getcwd() + "/..")' \
+  -ex 'python import JsDbg' \
+  ../bin/test_program

--- a/server/JsDbg.Gdb/testsuite/site.exp
+++ b/server/JsDbg.Gdb/testsuite/site.exp
@@ -1,0 +1,28 @@
+set tool jsdbg
+
+set timeout 3
+
+set gdb_prompt "(gdb) "
+set decimal "\[0-9\]+"
+set match ""
+
+proc test { passcond msg } {
+  global gdb_prompt
+  global match
+
+  expect {
+    -re "$passcond" {
+      pass "$msg"
+      set match $expect_out(0,string)
+    }
+    Error {
+      fail "$msg - Error"
+    }
+    $gdb_prompt {
+      fail "$msg - output doesn't match"
+    }
+    timeout {
+      unresolved "$msg - timeout"
+    }
+  }
+}

--- a/server/JsDbg.Gdb/testsuite/test_program.cc
+++ b/server/JsDbg.Gdb/testsuite/test_program.cc
@@ -1,0 +1,21 @@
+int global_var = 42;
+
+class Base {
+  int base_member_;
+};
+
+class Class : public Base {
+  struct {
+    int member_;
+  };
+};
+
+enum class Enum {
+  EFirst = 1
+};
+
+int main() {
+  Class c;
+  Enum e;
+  return global_var;
+}


### PR DESCRIPTION
This tests that GDB successfully loads the python script and that its
various functions work correctly on a test program.

Uses the "dejagnu" tool, which has poor documentation but
seems otherwise well suited to testing command-line interfaces
like this one (gdb uses it for its tests too).