### PR TITLE
[gdb] Handle the case of optimized-out variables

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -383,7 +383,7 @@ def GetSymbolsInStackFrame(instructionAddress, stackAddress, frameAddress):
             syms = syms + [s for s in block if s.addr_class != gdb.SYMBOL_LOC_TYPEDEF]
             block = block.superblock
 
-        return [SNamedSymbol(s, frame) for s in syms]
+        return [SNamedSymbol(s, frame) for s in syms if s.value(frame).address is not None]
     return None
 
 def LookupTypeSize(module, typename):

--- a/server/JsDbg.Gdb/testsuite/jsdbg.tests/basic.exp
+++ b/server/JsDbg.Gdb/testsuite/jsdbg.tests/basic.exp
@@ -45,7 +45,7 @@ regexp "($decimal)#($decimal)#($decimal)" $match full_match pc sp fp
 expect $gdb_prompt
 
 send "python print(JsDbg.GetSymbolsInStackFrame($pc, $sp, $fp))\n"
-test "\[\{test_program#c#$decimal#Class}, \{test_program#e#$decimal#Enum}]" "GetSymbolsInStackFrame"
+test "\[\{test_program#c#$decimal#Class}]" "GetSymbolsInStackFrame"
 expect $gdb_prompt
 
 send "python print(JsDbg.LookupTypeSize('test_program', 'int'))\n"


### PR DESCRIPTION
When a variable is optimized out, we can't access its address; this
change makes us handle that case by not returning such variables
from GetSymbolsInStackFrame and adjusts the test accordingly.