### PR TITLE
[gdb] Make WriteMemoryBytes compatible with Python 2

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -454,7 +454,7 @@ def ReadMemoryBytes(pointer, size):
 
 def WriteMemoryBytes(pointer, hexString):
     inferior = gdb.selected_inferior()
-    byteString = bytes.fromhex(hexString)
+    byteString = binascii.unhexlify(hexString)
     inferior.write_memory(pointer, byteString)
 
 def GetAttachedProcesses():


### PR DESCRIPTION
This makes it work for GDBs compiled with Python 2 as well
as Python 3.