### PR TITLE
[gdb] Don't repeat RESTOREFLAGS in debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,13 +15,11 @@ export DH_VERBOSE = 1
 
 export DOTNET_CLI_TELEMETRY_OPTOUT = 1
 export DOTNET_CLI_HOME := $(shell pwd)
+export RESTOREFLAGS := -s /usr/share/dotnet/sdk/NuGetFallbackFolder
 
 %:
 	dh $@
 
-override_dh_auto_build:
-	dh_auto_build -- DOTNET=/usr/bin/dotnet RESTOREFLAGS="-s /usr/share/dotnet/sdk/NuGetFallbackFolder"
-
 override_dh_auto_install:
-	dh_auto_install -- PREFIX=/usr DOTNET=/usr/bin/dotnet RESTOREFLAGS="-s /usr/share/dotnet/sdk/NuGetFallbackFolder"
+	dh_auto_install -- PREFIX=/usr
 


### PR DESCRIPTION
We also no longer need to set DOTNET as of 92f43b329822a5e34911b8820b20f8d5fa53e4b1