### PR TITLE
[gdb] Fix "make package" and rename to "make dist"

### DIFF
--- a/server/JsDbg.Gdb/Makefile
+++ b/server/JsDbg.Gdb/Makefile
@@ -2,7 +2,8 @@ PREFIX=/usr/local
 DOTNET=dotnet
 
 PUBLISH := $(shell pwd)/out
-PUBLISH_SC := $(shell pwd)/out_sa
+PUBLISH_SC_REL := out_sa
+PUBLISH_SC := $(shell pwd)/$(PUBLISH_SC_REL)
 
 BINDEPS=$(filter-out %extensions %JsDbg.py %JsDbg.Gdb, $(wildcard $(PUBLISH)/*))
 
@@ -37,11 +38,11 @@ check: bin/test_program
 
 # We don't want users of the tarball to require a dotnet install, so
 # let's build a self-contained binary.
-package:
-	$(DOTNET) publish -c Release -r linux-x64 --self-contained -o $(PUBLISH_SC)
+dist:
+	cd ../JsDbg.Stdio && $(DOTNET) publish -c Release -r linux-x64 --self-contained -o $(PUBLISH_SC)
 	cp JsDbg.py $(PUBLISH_SC)
 	@echo 'Creating jsdbg.tar.bz2'
-	@tar --transform="s#$(PUBLISH_SC)#jsdbg#" -c -j -f jsdbg.tar.bz2 $(PUBLISH_SC)
+	@tar --transform="s#$(PUBLISH_SC_REL)#jsdbg#" -c -j -f jsdbg.tar.bz2 $(PUBLISH_SC_REL)
 
 .PHONY: clean install all package
 

--- a/server/JsDbg.Stdio/JsDbgBase.py
+++ b/server/JsDbg.Stdio/JsDbgBase.py
@@ -42,14 +42,14 @@ class JsDbg:
         self.verbose = verbose
         rootDir = os.path.dirname(os.path.abspath(__file__))
         extensionSearchPath = [
-          rootDir + "/extensions", # from "make package"
+          rootDir + "/extensions", # from "make dist"
           rootDir + "/../../extensions", # inside a checkout
           rootDir + "/../../jsdbg/extensions", # from "make install"
         ]
         # The non-.DLL entries are for "standalone" builds; the DLL ones are
         # non-standalone and need to be run via the dotnet binary.
         execSearchPath = [
-          rootDir + "/JsDbg.Stdio", # from "make package"
+          rootDir + "/JsDbg.Stdio", # from "make dist"
           rootDir + "/../JsDbg.Gdb/out/JsDbg.Stdio", # in a checkout
           rootDir + "/../JsDbg.Gdb/out/JsDbg.Stdio.dll", # in a checkout
           rootDir + "/../../../lib/jsdbg/JsDbg.Stdio", # from make install


### PR DESCRIPTION
I did not update this target in e391967

The rename makes it clearer that this does not build a .deb

dist is a common name in automake:
https://www.gnu.org/software/automake/manual/html_node/Preparing-Distributions.html