### PR TITLE
[gdb] Simplify .deb build procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all:
 
 deb: clean
 	@echo '*** See debian/README.source for more information and help with troubleshoting. ***'
-	gbp buildpackage --git-ignore-branch -i.* -us -uc
+	dpkg-buildpackage -us -uc
 
 %:
 	$(MAKE) -C server/JsDbg.Gdb $@

--- a/debian/README.source
+++ b/debian/README.source
@@ -4,8 +4,8 @@ jsdbg for Debian
 Run "make deb" in the root directory to create a debian package.
 You may have to "git clean -d" first.
 
-You need to have "git-buildpackage" and "debhelper" installed:
-  sudo apt-get install git-buildpackage debhelper
+You need to have "dpkg-dev", "debhelper" and "dejagnu" installed:
+  sudo apt-get install dpkg-dev debhelper dejagnu
 
  -- Christian Biesinger <cbiesinger@google.com>  Tue, 11 Jun 2019 19:42:54 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,11 @@
-jsdbg (0.8.9-1) unstable; urgency=medium
+jsdbg (0.9.0) unstable; urgency=medium
 
   * Update extensions
   * Fix bugs in reading local variables and in writing memory
 
  -- Christian Biesinger <cbiesinger@google.com>  Tue, 30 Jul 2019 18:21:00 -0500
 
-jsdbg (0.8.9-1) unstable; urgency=medium
+jsdbg (0.8.9) unstable; urgency=medium
 
   * Initial release
 

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
If we configure this as a native package, we don't need to use
git-buildpackage, which means we don't need to worry about creating git tags.

A "native" package means that the debian/ directory is part of the original
source, which is what we have. ("Normal" debian packages have the debian
packaging scripts separately from the upstream source code)

Also mention the dejagnu build requirement.