### PR TITLE
Use bash shell for makefile

### DIFF
--- a/server/JsDbg.Gdb/Makefile
+++ b/server/JsDbg.Gdb/Makefile
@@ -1,6 +1,7 @@
 PREFIX=/usr/local
 DOTNET=dotnet
 
+SHELL := /bin/bash
 PUBLISH := $(shell pwd)/out
 PUBLISH_SC_REL := out_sa
 PUBLISH_SC := $(shell pwd)/$(PUBLISH_SC_REL)


### PR DESCRIPTION
The current makefile implementation doesn't work with certain sh shell versions. So we use the bash shell so that the makefile works more consistently for everyone.