### PR TITLE
[gdb] Put the resulting deb in the current directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ all:
 
 deb: clean
 	@echo '*** See debian/README.source for more information and help with troubleshoting. ***'
-	dpkg-buildpackage -us -uc
+	@# We can't use --filename=jsdbg-gdb.deb in BUILDPACKAGE_OPTS because too many steps
+	@# depend on keeping the filename as-is. So we'll just rename it afterwards.
+	BUILDPACKAGE_OPTS="--destdir=." dpkg-buildpackage -us -uc --build=binary --buildinfo-option=-u. --changes-option=-u.
+	mv jsdbg-gdb_*.deb jsdbg-gdb.deb
 
 %:
 	$(MAKE) -C server/JsDbg.Gdb $@

--- a/debian/control
+++ b/debian/control
@@ -8,10 +8,12 @@ Homepage: https://github.com/MicrosoftEdge/JsDbg
 Vcs-Git: https://github.com/MicrosoftEdge/JsDbg
 Vcs-Browser: https://github.com/MicrosoftEdge/JsDbg
 
-Package: jsdbg
+Package: jsdbg-gdb
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, dotnet-runtime-2.2
 Recommends: gdb
+Replaces: jsdbg
+Breaks: jsdbg
 Description: Browser-based debugger extensions
  Extends GDB with a `jsdbg' command that lets you visualize datastructures
  in a browser and can be extended using JavaScript.

--- a/debian/rules
+++ b/debian/rules
@@ -13,3 +13,5 @@ export RESTOREFLAGS := -s /usr/share/dotnet/sdk/NuGetFallbackFolder
 override_dh_auto_install:
 	dh_auto_install -- PREFIX=/usr
 
+override_dh_builddeb:
+	dh_builddeb $(BUILDPACKAGE_OPTS)


### PR DESCRIPTION
Unfortunately this will still put a .changes file in the parent
directory and I don't know how to make it not do that.

Also renames the resulting deb to "jsdbg-gdb.deb" (and ensures that
the package name is changed to that)
