### PR TITLE
[gdb] Better handle typedefs to anonymous unions

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -113,7 +113,17 @@ def IsFunctionPointer(t):
 
 
 def FormatType(symbol_type):
-    t = symbol_type.strip_typedefs()
+    # The type may be a typedef to an anonymous union (e.g.
+    # base::internal::LockImpl::NativeHandle). In that case, keep the
+    # typedef name so we have *some* name to refer to this type.
+    # (This is only an issue with clang,
+    # https://bugs.llvm.org/show_bug.cgi?id=43054)
+    stripped = symbol_type.strip_typedefs()
+    if stripped.name:
+        t = stripped
+    else:
+        t = symbol_type
+
     if IsFunctionPointer(t):
         # No good way to interop a function pointer back to python; lie and say it's a void*
         return "void *"


### PR DESCRIPTION
When compiled with clang, for a typedef to an anonymous union, gdb
will not be able to find a name and so 'name' is None. When that
happens, we should just not call strip_typedefs to keep a name
to refer to the type.

Because this only happens with clang, I have not written a testcase
for this bug. I did file a clang bug (see link in comment).

This shows up with base::internal::LockImpl::NativeHandle.