### PR TITLE
[gdb] Don't throw an exception for types that have no fields

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -154,8 +154,15 @@ def GetAllFields(module, type, includeBaseTypes):
     if t is None:
         return None
 
-    fields = t.fields()
     resultFields = []
+
+    try:
+        fields = t.fields()
+    except:
+        # If this is a type that has no fields, return instead of throwing
+        # an exception (e.g. 'char').
+        return resultFields
+
     for field in fields:
         if field.is_base_class:
             if not includeBaseTypes:


### PR DESCRIPTION
The JsDbg frontend will call GetAllFields even for types such as
'char'. For such types, accessing .fields() will throw an exception,
which makes the Objdiff extension fail. Instead, just return [].