### PR TITLE
Allow empty names for non-struct/union types

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -119,7 +119,8 @@ def FormatType(symbol_type):
     # (This is only an issue with clang,
     # https://bugs.llvm.org/show_bug.cgi?id=43054)
     stripped = symbol_type.strip_typedefs()
-    if stripped.name:
+    if stripped.name or (stripped.code != gdb.TYPE_CODE_STRUCT and
+                         stripped.code != gdb.TYPE_CODE_UNION):
         t = stripped
     else:
         t = symbol_type

--- a/server/JsDbg.Gdb/testsuite/jsdbg.tests/basic.exp
+++ b/server/JsDbg.Gdb/testsuite/jsdbg.tests/basic.exp
@@ -6,6 +6,12 @@ expect $gdb_prompt
 send "run\n"
 expect $gdb_prompt
 
+# Some tests for FormatType
+send "python print(JsDbg.FormatType(gdb.lookup_type('IntPointer')))\n"
+test "int \\\*" "Test that we strip typedefs from pointer types"
+expect $gdb_prompt
+
+# Tests for the IDebugger implementation
 send "python print(JsDbg.LookupGlobalSymbol('test_program', 'global_var'))\n"
 test "{int#$decimal}" "LookupGlobalSymbol"
 regexp $decimal $match pointer

--- a/server/JsDbg.Gdb/testsuite/test_program.cc
+++ b/server/JsDbg.Gdb/testsuite/test_program.cc
@@ -1,5 +1,8 @@
 int global_var = 42;
 
+typedef int* IntPointer;
+IntPointer ip;
+
 class Base {
   int base_member_;
 };


### PR DESCRIPTION
In particular, for a typedef to a pointer, the stripped type will have
no name (it's a pointer to a type with a name). Allow for that.

Followup to 4ba3725f48cc2ec91ea9c6eab5cdf88228abe656