### PR TITLE
CCLayerTree: Fix GetRoots to work with a unique ptr for render widget

### DIFF
--- a/extensions/target-specific/chromium/cclayertree/cclayertree.js
+++ b/extensions/target-specific/chromium/cclayertree/cclayertree.js
@@ -37,7 +37,12 @@ Loader.OnLoad(function() {
             // to have the 'most important' layer tree host be the first entry.
             return DbgObject.global(Chromium.RendererProcessSyntheticModuleName, "g_view_map", undefined, "content")
             .then((viewMap) => {
-                return Promise.map(viewMap.F("Object").array("Values"), renderViewImplPointer => renderViewImplPointer.deref().f("render_widget_", "").f("layer_tree_view_").F("Object").f("layer_tree_host_").F("Object"));
+                return Promise.map(viewMap.F("Object").array("Values"), renderViewImplPointer => renderViewImplPointer.deref().f("render_widget_", "")
+                .then((layerTreeViewOwnerOrUniquePtr) => {
+                    return layerTreeViewOwnerOrUniquePtr.F("Object")
+                    .then(null, () => layerTreeViewOwnerOrUniquePtr);
+                })
+                .then((layerTreeViewOwner) => layerTreeViewOwner.f("layer_tree_view_").F("Object").f("layer_tree_host_").F("Object")))
             })
             .then(null, (error) => {
                 var errorMessage = ErrorMessages.CreateErrorsList(error) +


### PR DESCRIPTION
This change (https://chromium.googlesource.com/chromium/src/+/3433ee045916f591c95686289606a102c87d2ae9) turned the RenderWidget pointer on RenderViewImpl into a unique ptr, which broke GetRoots for the CCLayerTree extension. Fixing this by adding a call to dereference the unique ptr.