### PR TITLE
Don't open a browser when $DISPLAY is not set

### DIFF
--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -143,11 +143,15 @@ def ModuleForAddress(pointer):
 def ServerStarted(url):
     global jsdbg_url
     jsdbg_url = url
-    print('Opening browser for %s' % (url))
-    print('If you are debugging the default browser, manually open the URL in a')
-    print('different browser.')
-    webbrowser.open_new_tab(url)
-
+    if os.getenv('DISPLAY'):
+      print('Opening browser for %s' % (url))
+      print('If you are debugging the default browser, manually open the URL in a')
+      print('different browser.')
+      webbrowser.open_new_tab(url)
+    else:
+      print('Not opening browser because $DISPLAY is not set.')
+      print('Please load %s in a browser yourself.' % (url))
+      print('To set up SSH port forwarding: <Enter> ~C -L <port>:localhost:<port>')
 
 def ServerExited():
     print("JsDbg: server exited or crashed. To restart, type 'jsdbg'.")

--- a/server/JsDbg.Gdb/JsDbg.py
+++ b/server/JsDbg.Gdb/JsDbg.py
@@ -501,5 +501,6 @@ class JsDbgCmd(gdb.Command):
             verbose_param.value)
     else:
         ServerStarted(jsdbg_url)
+    self.dont_repeat()
 
 JsDbgCmd()

--- a/server/JsDbg.Gdb/JsDbg_test.py
+++ b/server/JsDbg.Gdb/JsDbg_test.py
@@ -14,6 +14,9 @@ class GdbModule(object):
         def __init__(self, name, type):
             pass
 
+        def dont_repeat(self):
+            pass
+
     class Parameter(object):
         def __init__(self, name, cmd_class, type):
             pass


### PR DESCRIPTION
This also prints some instructions for setting up SSH port forwarding.

I've also used this opportunity to set things up such that pressing Enter will
not repeat the jsdbg command.