### PR TITLE
Support global lookup of symbols within scopes (namespaces, outer classes, etc.) on Windows

### DIFF
--- a/extensions/dbgobject/core/dbgobject.js
+++ b/extensions/dbgobject/core/dbgobject.js
@@ -122,7 +122,7 @@ Loader.OnLoad(function() {
             {name:"moduleName", type:"string", description:"The name of the module containing the symbol."},
             {name:"symbol", type:"string", description:"The global symbol to lookup."},
             {name: "typeName", type:"string", description: "(optional) The type name of the symbol to look up."},
-            {name: "scopes", type:"array of strings", description: "(optional) Array of scopes of the symbol to look up (namespace, outer class, etc.). Order: [outermost scope, ..., innermost scope]."}
+            {name: "scopes", type:"array of strings", description: "(optional) Array of scopes of the symbol to look up (namespace, outer class, etc.). Order: [outermost scope, ..., innermost scope]. An anonymous namespace should be declared as \"anonymous namespace\"."}
         ]
     }
     DbgObject.global = function(moduleName, symbol, typeName, scopes) {

--- a/extensions/dbgobject/core/dbgobject.js
+++ b/extensions/dbgobject/core/dbgobject.js
@@ -122,12 +122,12 @@ Loader.OnLoad(function() {
             {name:"moduleName", type:"string", description:"The name of the module containing the symbol."},
             {name:"symbol", type:"string", description:"The global symbol to lookup."},
             {name: "typeName", type:"string", description: "(optional) The type name of the symbol to look up."},
-            {name: "scope", type:"string", description: "(optional) The scope of the symbol to look up (namespace, outer class, etc.). Required on some platforms."}
+            {name: "scopes", type:"array of strings", description: "(optional) Array of scopes of the symbol to look up (namespace, outer class, etc.). Order: [outermost scope, ..., innermost scope]."}
         ]
     }
-    DbgObject.global = function(moduleName, symbol, typeName, scope) {
+    DbgObject.global = function(moduleName, symbol, typeName, scopes) {
         return new PromisedDbgObject(
-            moduleBasedLookup(moduleName, JsDbgPromise.LookupGlobalSymbol, symbol, typeName, scope)
+            moduleBasedLookup(moduleName, JsDbgPromise.LookupGlobalSymbol, symbol, typeName, scopes)
             .then(function(result) {
                 return DbgObject.create(DbgObjectType(result.module, result.type), result.pointer);
             })

--- a/extensions/jsdbg/core/jsdbg.js
+++ b/extensions/jsdbg/core/jsdbg.js
@@ -446,7 +446,7 @@ Loader.OnLoad(function () {
                 {name:"module", type:"string", description:"The module containing the symbol."},
                 {name:"symbol", type:"string", description:"The symbol to evaluate."},
                 {name:"typeName", type:"string", description: "The type name of the symbol to look up."},
-                {name: "scopes", type:"array of strings", description: "(optional) Array of scopes of the symbol to look up (namespace, outer class, etc.). Order: [outermost scope, ..., innermost scope]."},
+                {name: "scopes", type:"array of strings", description: "Array of scopes of the symbol to look up (namespace, outer class, etc.). Order: [outermost scope, ..., innermost scope]. An anonymous namespace should be declared as \"anonymous namespace\"."},
                 {name:"callback", type:"function(object)", description:"A callback that is called when the operation succeeds or fails."}
             ]
         },

--- a/extensions/jsdbg/core/jsdbg.js
+++ b/extensions/jsdbg/core/jsdbg.js
@@ -446,18 +446,18 @@ Loader.OnLoad(function () {
                 {name:"module", type:"string", description:"The module containing the symbol."},
                 {name:"symbol", type:"string", description:"The symbol to evaluate."},
                 {name:"typeName", type:"string", description: "The type name of the symbol to look up."},
-                {name:"scope", type:"string", description: "The scope of the symbol to look up (namespace, outer class, etc.). Required on some platforms."},
+                {name: "scopes", type:"array of strings", description: "(optional) Array of scopes of the symbol to look up (namespace, outer class, etc.). Order: [outermost scope, ..., innermost scope]."},
                 {name:"callback", type:"function(object)", description:"A callback that is called when the operation succeeds or fails."}
             ]
         },
-        LookupGlobalSymbol: function(module, symbol, typeName, scope, callback) {
+        LookupGlobalSymbol: function(module, symbol, typeName, scopes, callback) {
             var typenameStr = "";
             if (typeName)
                 typenameStr = "&typeName=" + esc(typeName);
-            var scopeStr = "";
-            if (scope)
-                scopeStr = "&scope=" + esc(scope);
-            JsDbgTransport.JsonRequest("/jsdbg-server/global?module=" + esc(module) + "&symbol=" + esc(symbol) + typenameStr + scopeStr, callback, JsDbgTransport.CacheType.Cached);
+            var scopesStr = "";
+            if (scopes)
+                scopesStr = "&scopes=" + esc(scopes);
+            JsDbgTransport.JsonRequest("/jsdbg-server/global?module=" + esc(module) + "&symbol=" + esc(symbol) + typenameStr + scopesStr, callback, JsDbgTransport.CacheType.Cached);
         },
 
         _help_GetCallStack: {

--- a/extensions/target-specific/chromium/blink/blink-helpers/blink-helpers.js
+++ b/extensions/target-specific/chromium/blink/blink-helpers/blink-helpers.js
@@ -773,7 +773,11 @@ Loader.OnLoad(function() {
             description: "Returns (a promise to) a collection of documents for all web frames in the current renderer process."
         },
         GetDocuments: () => {
-            return DbgObject.global(Chromium.RendererProcessSyntheticModuleName, "g_frame_map", undefined, "content::(anonymous namespace)")
+            return DbgObject.global(Chromium.RendererProcessSyntheticModuleName, "g_frame_map", undefined, ["content", "anonymous namespace"])
+            .then(null, () => {
+                // Global symbol lookup failed; try without scopes (needed for older versions of Chromium on Windows)
+                return DbgObject.global(Chromium.RendererProcessSyntheticModuleName, "g_frame_map");
+            })
             .then((frameMap) => Promise.map(frameMap.F("Object").array("Keys"), (webFramePointer) => webFramePointer.deref()))
             .then((webFrames) => {
                 // Put the main frame (frame with a null parent) at the front of the array.

--- a/server/JsDbg.Core/IDebugger.cs
+++ b/server/JsDbg.Core/IDebugger.cs
@@ -113,7 +113,7 @@ namespace JsDbg.Core {
         Task<IEnumerable<SConstantResult>> LookupConstants(string module, string type, ulong constantValue);
         Task<SConstantResult> LookupConstant(string module, string type, string constantName);
         Task<SFieldResult> LookupField(string module, string typename, string fieldName);
-        Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol, string typeName, string scope);
+        Task<SSymbolResult> LookupGlobalSymbol(string module, string symbol, string typeName, string[] scopes);
         Task<SModule> GetModuleForName(string module);
         Task<IEnumerable<SStackFrame>> GetCallStack(int frameCount);
         Task<IEnumerable<SNamedSymbol>> GetSymbolsInStackFrame(ulong instructionAddress, ulong stackAddress, ulong frameAddress);

--- a/server/JsDbg.Core/WebServer.cs
+++ b/server/JsDbg.Core/WebServer.cs
@@ -774,7 +774,7 @@ namespace JsDbg.Core {
             string module = query["module"];
             string symbol = query["symbol"];
             string typeName = query["typeName"];
-            string scope = query["scope"];
+            string scopes = query["scopes"];
 
             if (module == null || symbol == null) {
                 fail();
@@ -782,7 +782,7 @@ namespace JsDbg.Core {
             }
             string responseString;
             try {
-                SSymbolResult result = await this.debugger.LookupGlobalSymbol(module, symbol, typeName, scope);
+                SSymbolResult result = await this.debugger.LookupGlobalSymbol(module, symbol, typeName, scopes != null ? scopes.Split(',') : null);
                 responseString = String.Format("{{ \"pointer\": {0}, \"module\": \"{1}\", \"type\": \"{2}\" }}", result.Pointer, result.Module, result.Type);
             } catch (DebuggerException ex) {
                 responseString = ex.JSONError;

--- a/server/JsDbg.Windows/DiaDebugger.cs
+++ b/server/JsDbg.Windows/DiaDebugger.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Dia2Lib;
 using JsDbg.Core;
@@ -303,9 +304,8 @@ namespace JsDbg.Windows.Dia {
             return (await this.LoadType(module, typename)).Size;
         }
 
-        public async Task<SSymbolResult> LookupGlobalSymbol(string moduleName, string symbolName, string typeName, string scope) {
-            // The scope is not needed to lookup global symbols with DIA.
-
+        public async Task<SSymbolResult> LookupGlobalSymbol(string moduleName, string symbolName, string typeName, string[] scopes) {
+            symbolName = GetScopePrefix(scopes) + symbolName;
             Dia2Lib.IDiaSession session = await this.debuggerEngine.DiaLoader.LoadDiaSession(moduleName);
             if (session != null) {
                 // We have a DIA session, use that.
@@ -336,6 +336,21 @@ namespace JsDbg.Windows.Dia {
             } else {
                 return await this.debuggerEngine.LookupGlobalSymbol(moduleName, symbolName, typeName);
             }
+        }
+
+        private string GetScopePrefix(string[] scopes) {
+            StringBuilder resultBuilder = new StringBuilder();
+            if (scopes != null) {
+                foreach (String scope in scopes) {
+                    if (scope.Equals("anonymous namespace")) {
+                        resultBuilder.Append('`').Append(scope).Append('\'');
+                    } else {
+                        resultBuilder.Append(scope);
+                    }
+                    resultBuilder.Append("::");
+                }
+            }
+            return resultBuilder.ToString();
         }
 
         public Task<SModule> GetModuleForName(string module) {


### PR DESCRIPTION
The `DbgObject.global` API takes a scope parameter; however, it is currently ignored on Windows. With the latest compiler changes affecting Chromium symbols like `g_frame_map`, the scope now needs to be considered when querying for symbols on Windows. To that end, this change adjusts the symbol name to include the scope prefix before querying the debugger/symbol files on Windows.

There is an additional complication that needs to be addressed to handle anonymous namespaces correctly. On Linux, an anonymous namespace is annotated as `(anonymous namespace)`, whereas on Windows, it is annotated as `` `anonymous namespace'``. To handle this discrepancy, the `DbgObject.global` API now takes an array of scope strings (ordered [outermost scope, ..., innermost scope]), and within this array, an anonymous namespace is simply written as "anonymous namespace". Then, this `scopes` array will be transformed into a scope prefix string, with the Linux/Windows specific code resolving anonymous namespaces in platform-specific ways.