### PR TITLE
Modernize debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Christian Biesinger <cbiesinger@google.com>
 Uploaders: Sanket Joshi <sajos@microsoft.com>
-Build-Depends: debhelper (>= 10), dotnet-sdk-2.2, dejagnu, gdb
+Build-Depends: debhelper (>= 10), dotnet-sdk-5.0, dejagnu, gdb
 Standards-Version: 4.1.2
 Homepage: https://github.com/MicrosoftEdge/JsDbg
 Vcs-Git: https://github.com/MicrosoftEdge/JsDbg
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/MicrosoftEdge/JsDbg
 
 Package: jsdbg-gdb
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, dotnet-runtime-2.2
+Depends: ${misc:Depends}, ${shlibs:Depends}, dotnet-runtime-5.0
 Recommends: gdb
 Replaces: jsdbg
 Breaks: jsdbg

--- a/server/JsDbg.Gdb/Makefile
+++ b/server/JsDbg.Gdb/Makefile
@@ -34,9 +34,9 @@ check: bin/test_program
 	@# so if $(RESTOREFLAGS) is set, just skip this test.
 	if test x"$(RESTOREFLAGS)" = x; then cd ../JsDbg.Stdio.Tests && $(DOTNET) restore $(RESTOREFLAGS) && $(DOTNET) test --no-restore; fi
 	cd testsuite && runtest
-	python ../JsDbg.Stdio/JsDbgBase_test.py
+	python2 ../JsDbg.Stdio/JsDbgBase_test.py
 	python3 ../JsDbg.Stdio/JsDbgBase_test.py
-	python JsDbg_test.py
+	python2 JsDbg_test.py
 	python3 JsDbg_test.py
 
 # We don't want users of the tarball to require a dotnet install, so


### PR DESCRIPTION
- Depend on the .NET SDK 5.0 instead of 2.2
- Run the Python 2 tests using `python2` instead of just `python`