### PR TITLE
Use -maxcpucount:1 to fix debian build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,7 +10,7 @@ export DOTNET_CLI_HOME := $(shell pwd)
 	dh $@
 
 override_dh_auto_install:
-	dh_auto_install -- PREFIX=/usr
+	dh_auto_install -- PREFIX=/usr PUBLISHFLAGS=-maxcpucount:1
 
 override_dh_builddeb:
 	dh_builddeb $(BUILDPACKAGE_OPTS)

--- a/server/JsDbg.Gdb/Makefile
+++ b/server/JsDbg.Gdb/Makefile
@@ -12,7 +12,7 @@ PYTHON_FILES=JsDbg.py ../JsDbg.Stdio/JsDbg{Base,Types}.py
 
 all: bin/test_program
 	cd ../JsDbg.Stdio && $(DOTNET) restore $(RESTOREFLAGS)
-	cd ../JsDbg.Stdio && $(DOTNET) publish -c Release --no-restore -o $(PUBLISH)
+	cd ../JsDbg.Stdio && $(DOTNET) publish -c Release --no-restore -o $(PUBLISH) $(PUBLISHFLAGS)
 
 clean:
 	rm -rf bin $(PUBLISH) $(PUBLISH_SC) ../JsDbg.{Core,Stdio,Stdio.Tests}/{bin,obj} jsdbg-gdb.tar.bz2 {.,../JsDbg.Stdio}/{*.pyc,__pycache__}


### PR DESCRIPTION
As described in https://github.com/dotnet/sdk/issues/2526. Otherwise,
`dotnet publish` returns with exit status 1 during `make install`.